### PR TITLE
Human copyable format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Gettext is an **internationalization** (i18n) and **localization** (l10n) system
 
      ```elixir
      def deps do
-       [{:gettext, ">= 0.0.0"}]
+       [
+         {:gettext, ">= 0.0.0"}
+       ]
      end
      ```
 
@@ -18,7 +20,9 @@ Gettext is an **internationalization** (i18n) and **localization** (l10n) system
 
      ```elixir
      def project do
-       [compilers: [:gettext] ++ Mix.compilers()]
+       [
+         compilers: [:gettext] ++ Mix.compilers()
+       ]
      end
      ```
 


### PR DESCRIPTION
The previous version of formatting causes difficulties when trying to copy a line with a double click.
After inserting into the code, you have to delete parentheses.
In my opinion, this formatting option is more convenient and adapted for copy paste.