### PR TITLE
Support configuration of locales by environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.18.0
+
+* Add `:allowed_locales` to restrict the locales bundled in the backend
+
 ## v0.17.4
 
 * Do not change the return types of `*_noop` macros (regression in v0.17.2 and v0.17.3)

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -472,6 +472,9 @@ defmodule Gettext do
       This reduces compilation times and beam file sizes for large projects.
       This option requires Elixir v1.6.
 
+    * `:allowed_locales` - a list of locales to bundle in the backend.
+      Defaults to all the locales discovered in the `:priv` directory
+
   ### Mix tasks configuration
 
   You can configure Gettext Mix tasks under the `:gettext` key in the

--- a/test/fixtures/test_application/translations/es/LC_MESSAGES/default.po
+++ b/test/fixtures/test_application/translations/es/LC_MESSAGES/default.po
@@ -1,0 +1,2 @@
+msgid "Hello world"
+msgstr "Hola mundo"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -6,6 +6,10 @@ defmodule GettextTest.TranslatorWithCustomPriv do
   use Gettext, otp_app: :test_application, priv: "translations"
 end
 
+defmodule GettextTest.TranslatorWithAllowedLocales do
+  use Gettext, otp_app: :test_application, priv: "translations", allowed_locales: ["es"]
+end
+
 defmodule GettextTest.TranslatorWithCustomPluralForms do
   defmodule Plural do
     @behaviour Gettext.Plural
@@ -40,11 +44,13 @@ defmodule GettextTest do
 
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithCustomPriv
+  alias GettextTest.TranslatorWithAllowedLocales
   alias GettextTest.TranslatorWithCustomPluralForms
   alias GettextTest.HandleMissingTranslation
 
   require Translator
   require TranslatorWithCustomPriv
+  require TranslatorWithAllowedLocales
 
   test "the default locale is \"en\"" do
     assert Gettext.get_locale() == "en"
@@ -133,6 +139,14 @@ defmodule GettextTest do
 
     assert TranslatorWithCustomPriv.lgettext("it", "errors", nil, "Invalid email address", %{}) ==
              {:ok, "Indirizzo email non valido"}
+  end
+
+  test "allowed_locales ignores other locales" do
+    assert TranslatorWithAllowedLocales.lgettext("it", "default", nil, "Hello world", %{}) ==
+             {:default, "Hello world"}
+
+    assert TranslatorWithAllowedLocales.lgettext("es", "default", nil, "Hello world", %{}) ==
+             {:ok, "Hola mundo"}
   end
 
   test "using a custom Gettext.Plural module" do
@@ -700,7 +714,8 @@ defmodule GettextTest do
 
   test "known_locales/1: returns all the locales for which a backend has PO files" do
     assert Gettext.known_locales(Translator) == ["it"]
-    assert Gettext.known_locales(TranslatorWithCustomPriv) == ["it"]
+    assert Gettext.known_locales(TranslatorWithCustomPriv) == ["es", "it"]
+    assert Gettext.known_locales(TranslatorWithAllowedLocales) == ["es"]
   end
 
   test "a warning is issued in l(n)gettext when the domain contains slashes" do


### PR DESCRIPTION
Added a configuration option `allowed_locales` to restrict the locales that gettext bundles in the backend.

This patch introduces slightly more changes than I was expecting. 
In the previous version, the filesystem was read twice. One to discover the locales, and another to load the po files.
If I had kept this approach, I should have done the filtering of locales twice, with different inputs.
In the current approach, I reach for the filesystem once, and filter the PO files there based on the configuration, returning the path, locale and domain in the same data structure.
This structure is then cascaded to the different compilers

closes #238 