### PR TITLE
Ensure that touching the PO file happens after the manifest

### DIFF
--- a/test/mix/tasks/compile.gettext_test.exs
+++ b/test/mix/tasks/compile.gettext_test.exs
@@ -16,6 +16,7 @@ defmodule Mix.Tasks.Compile.GettextTest do
     Mix.Project.push(MyProject)
     File.rm_rf!(@po_path)
     File.rm_rf!(Path.join(Mix.Project.app_path(), ".compile_tmp_gettext_foo"))
+    File.rm_rf!(Path.join(Mix.Project.app_path(), ".compile_tmp_gettext_bar"))
 
     on_exit(fn ->
       Mix.Project.pop()
@@ -66,7 +67,7 @@ defmodule Mix.Tasks.Compile.GettextTest do
              ["tmp/gettext/foo/en/LC_MESSAGES/hello.po"]
 
     # Touch existing .po file
-    touch_po("foo/en/LC_MESSAGES/hello.po")
+    touch_po_after_manifest("foo/en/LC_MESSAGES/hello.po", ".compile_tmp_gettext_foo")
     assert run([]) == {:ok, []}
 
     assert read_manifest(".compile_tmp_gettext_foo") ==
@@ -84,9 +85,11 @@ defmodule Mix.Tasks.Compile.GettextTest do
     end
   end
 
-  defp touch_po(path) do
-    path = Path.join(@po_path, path)
-    touch_po(path, File.stat!(path).mtime)
+  defp touch_po_after_manifest(po_path, manifest_path) do
+    po_path = Path.join(@po_path, po_path)
+    manifest_path = Path.join(Mix.Project.app_path(), manifest_path)
+    latest_time = [File.stat!(po_path).mtime, File.stat!(manifest_path).mtime] |> Enum.max()
+    touch_po(po_path, latest_time)
   end
 
   defp touch_po(path, current) do


### PR DESCRIPTION
There is a chance that the previous assertion leaves the timestamps in
the following state:

  | File                              | Timestamp
  ------------------------------------|------------------------------
  | Manifest .compile_tmp_gettext_bar | {{2020, 1, 21}, {17, 49, 57}}
  | Manifest .compile_tmp_gettext_foo | {{2020, 1, 21}, {17, 49, 57}}
  | PO foo/en/LC_MESSAGES/hello.po    | {{2020, 1, 21}, {17, 49, 56}}

which means that when touching `hello.po` to have a newer timestamp, ends
up with the same timestamp as the manifest. This marks the whole manifest as "not stale".

With this patch, i'm forcing the touch of the file to be later than the
oldest of the timestamps of the PO or the manifest.

This should fix the error https://travis-ci.org/elixir-gettext/gettext/jobs/638875306?utm_medium=notification&utm_source=github_status

![image](https://user-images.githubusercontent.com/203349/72834884-ff526f00-3c89-11ea-9411-7b04bc631cfa.png)

