### PR TITLE
Allow sorting strings by msgid

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -514,7 +514,7 @@ defmodule Gettext do
     * `:sort_by_msgid` - a boolean that modifies the sorting behavior.
       By default, the order of existing translations in a POT file is kept, and new
       translations are appended to the file. If `:sort_by_msgid` is set to true,
-      existing and new translations will be mixed and be sorted alphabetically by msgid.
+      existing and new translations will be mixed and sorted alphabetically by msgid.
   """
 
   defmodule Error do

--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -511,6 +511,10 @@ defmodule Gettext do
       reference comments will not be written when extracting translations or merging
       translations, and the ones already found in files will be discarded.
 
+    * `:sort_by_msgid` - a boolean that modifies the sorting behavior.
+      By default, the order of existing translations in a POT file is kept, and new
+      translations are appended to the file. If `:sort_by_msgid` is set to true,
+      existing and new translations will be mixed and be sorted alphabetically by msgid.
   """
 
   defmodule Error do

--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -298,8 +298,22 @@ defmodule Gettext.Extractor do
     # with the translations that only appear in `new`.
     unique_new = Enum.reject(new.translations, &PO.Translations.find(existing.translations, &1))
 
+    translations = old_and_merged ++ unique_new
+
+    translations =
+      if gettext_config[:sort_by_msgid] do
+        Enum.sort_by(translations, fn t ->
+          case PO.Translations.key(t) do
+            {_, {msgid, _}} -> msgid
+            {_, msgid} -> msgid
+          end
+        end)
+      else
+        translations
+      end
+
     %PO{
-      translations: old_and_merged ++ unique_new,
+      translations: translations,
       headers: existing.headers,
       top_of_the_file_comments: existing.top_of_the_file_comments
     }

--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -302,12 +302,7 @@ defmodule Gettext.Extractor do
 
     translations =
       if gettext_config[:sort_by_msgid] do
-        Enum.sort_by(translations, fn t ->
-          case PO.Translations.key(t) do
-            {_, {msgid, _}} -> msgid
-            {_, msgid} -> msgid
-          end
-        end)
+        Enum.sort_by(translations, & &1.msgid)
       else
         translations
       end

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -3,6 +3,7 @@ defmodule Gettext.ExtractorTest do
   alias Gettext.Extractor
   alias Gettext.PO
   alias Gettext.PO.Translation
+  alias Gettext.PO.PluralTranslation
 
   @pot_path "../../tmp/" |> Path.expand(__DIR__) |> Path.relative_to_cwd()
 
@@ -203,6 +204,40 @@ defmodule Gettext.ExtractorTest do
       assert t1.msgid == [msgid]
       assert t1.references == [{"live_streaming.ex", 40}]
       assert t2.msgid == ["new translation"]
+    end
+
+    test "order can be alphabetical if desired" do
+      # Old and new translations are mixed together and ordered alphabetically.
+      foo_translation = %Translation{msgid: "foo", references: [{"foo.ex", 1}]}
+      bar_translation = %Translation{msgid: "bar", references: [{"bar.ex", 1}]}
+
+      baz_translation = %PluralTranslation{
+        msgid: "baz",
+        msgid_plural: "bazs",
+        references: [{"baz.ex", 1}]
+      }
+
+      qux_translation = %Translation{msgid: "qux", references: [{"bar.ex", 1}]}
+
+      po1 = %PO{
+        translations: [
+          foo_translation,
+          qux_translation,
+          bar_translation
+        ]
+      }
+
+      po2 = %PO{
+        translations: [
+          baz_translation,
+          foo_translation,
+          bar_translation
+        ]
+      }
+
+      %PO{translations: translations} = Extractor.merge_template(po1, po2, sort_by_msgid: true)
+
+      assert Enum.map(translations, & &1.msgid) == ~w(bar baz foo qux)
     end
   end
 

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -208,16 +208,16 @@ defmodule Gettext.ExtractorTest do
 
     test "order can be alphabetical if desired" do
       # Old and new translations are mixed together and ordered alphabetically.
-      foo_translation = %Translation{msgid: "foo", references: [{"foo.ex", 1}]}
-      bar_translation = %Translation{msgid: "bar", references: [{"bar.ex", 1}]}
+      foo_translation = %Translation{msgid: ["foo"], references: [{"foo.ex", 1}]}
+      bar_translation = %Translation{msgid: ["bar"], references: [{"bar.ex", 1}]}
 
       baz_translation = %PluralTranslation{
-        msgid: "baz",
-        msgid_plural: "bazs",
+        msgid: ["baz"],
+        msgid_plural: ["bazs"],
         references: [{"baz.ex", 1}]
       }
 
-      qux_translation = %Translation{msgid: "qux", references: [{"bar.ex", 1}]}
+      qux_translation = %Translation{msgid: ["qux"], references: [{"bar.ex", 1}]}
 
       po1 = %PO{
         translations: [
@@ -237,7 +237,7 @@ defmodule Gettext.ExtractorTest do
 
       %PO{translations: translations} = Extractor.merge_template(po1, po2, sort_by_msgid: true)
 
-      assert Enum.map(translations, & &1.msgid) == ~w(bar baz foo qux)
+      assert Enum.map(translations, &Enum.at(&1.msgid, 0)) == ~w(bar baz foo qux)
     end
   end
 


### PR DESCRIPTION
I have been working on one Phoenix app with a few people for 1 year now. Every time we happened to add strings to the same Gettext domain on two different feature branches, we would get merge conflicts because the standard behavior of Gettext is to append strings to the end of the file. This is a minor inconvenience for a single file, but a bit annoying if you have more than 5 languages.

We came to the conclusion that we might decrease how often conflicts happen if we changed the default behavior - instead of appending strings at the end, which guarantees conflicts every time, we want to sort them alphabetically by `msgid`.

We used that approach for a few months now, and it does work for decreasing the number of merge conflicts. Thus I want to suggest it as a option for everyone :).

The downside is that the files might change the first time you run `mix gettext.extract` after you resolved conflicts manually and didn't pay attention to ordering the strings.