### PR TITLE
Configurable Default Domain

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -42,8 +42,9 @@ defmodule Gettext do
         3
       )
 
-  The arguments for the Gettext macros and their order can be derived from
-  their names. For `dpgettext/4` the arguments are: `domain`, `context`, `msgid`, `bindings` (default to `%{}`).
+  The arguments for the Gettext macros and their order can be derived froe
+  their names. For `dpgettext/4` the arguments are: `domain`, `context`,
+  `msgid`, `bindings` (default to `%{}`).
 
   Translations are looked up from `.po` files. In the following sections we will
   explore exactly what are those files before we explore the "Gettext API" in
@@ -151,6 +152,18 @@ defmodule Gettext do
   it makes it hard to track which locale each backend is using:
 
       config :my_app, MyApp.Gettext, default_locale: "fr"
+
+  ### Default Domain
+
+  Each backend can be configured with a specific `:default_domain`
+  that replaces `"default"` in `gettext/2`, `pgettext/3`, and `ngettext/4`
+  for that backend.
+
+      defmodule MyApp.Gettext do
+        use Gettext, otp_app: :my_app, default_domain: "messages"
+      end
+
+      config :my_app, MyApp.Gettext, default_domain: "translations"
 
   ## Gettext API
 
@@ -274,7 +287,10 @@ defmodule Gettext do
       MyApp.Gettext.dgettext("errors", "Error!")
       #=> "Errore!"
 
-  When `gettext` or `ngettext` are used, the `"default"` domain is used.
+  When backend `gettext`, `ngettext`, or `pgettext` are used, the backend's
+  default domain is used (which defaults to "default"). The `Gettext`
+  functions accepting a backend (`gettext/3`, `ngettext/5`, and `pgettext/4`)
+  _always_ use a domain of "default".
 
   ## Contexts
 

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -140,7 +140,8 @@ defmodule Gettext.Backend do
   @macrocallback pgettext(msgctxt :: String.t(), msgid :: String.t()) :: Macro.t()
 
   @doc """
-  Same as `dgettext("default", msgid, %{})`.
+  Same as `dgettext("default", msgid, %{})`, but will use a per-backend
+  configured default domain if provided.
 
   See also `Gettext.gettext/3`.
   """
@@ -242,7 +243,8 @@ defmodule Gettext.Backend do
                  ) :: Macro.t()
 
   @doc """
-  Same as `dngettext("default", msgid, msgid_plural, n, bindings)`.
+  Same as `dngettext("default", msgid, msgid_plural, n, bindings)`, but will
+  use a per-backend configured default domain if provided.
 
   See also `Gettext.ngettext/5`.
   """
@@ -305,7 +307,8 @@ defmodule Gettext.Backend do
                  ) :: Macro.t()
 
   @doc """
-  Same as `dngettext_noop("default", msgid, mgsid_plural)`.
+  Same as `dngettext_noop("default", msgid, mgsid_plural)`, but will use a
+  per-backend configured default domain if provided.
   """
   @macrocallback ngettext_noop(msgid :: String.t(), msgid_plural :: String.t()) :: Macro.t()
 

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -11,6 +11,7 @@ defmodule Gettext.Compiler do
   require Logger
 
   @default_priv "priv/gettext"
+  @default_domain "default"
   @po_wildcard "*/LC_MESSAGES/*.po"
 
   @doc false
@@ -38,6 +39,9 @@ defmodule Gettext.Compiler do
 
     default_locale =
       opts[:default_locale] || quote(do: Application.fetch_env!(:gettext, :default_locale))
+    default_domain = opts[:default_domain] || @default_domain
+
+    Module.put_attribute(env.module, :gettext_default_domain, default_domain)
 
     quote do
       @behaviour Gettext.Backend
@@ -48,6 +52,7 @@ defmodule Gettext.Compiler do
       def __gettext__(:otp_app), do: unquote(otp_app)
       def __gettext__(:known_locales), do: unquote(known_locales)
       def __gettext__(:default_locale), do: unquote(default_locale)
+      def __gettext__(:default_domain), do: unquote(default_domain)
 
       # The manifest lives in the root of the priv
       # directory that contains .po/.pot files.
@@ -102,14 +107,16 @@ defmodule Gettext.Compiler do
       end
 
       defmacro gettext_noop(msgid) do
+        domain = __gettext__(:default_domain)
         quote do
-          unquote(__MODULE__).dpgettext_noop("default", nil, unquote(msgid))
+          unquote(__MODULE__).dpgettext_noop(unquote(domain), nil, unquote(msgid))
         end
       end
 
       defmacro pgettext_noop(msgid, context) do
+        domain = __gettext__(:default_domain)
         quote do
-          unquote(__MODULE__).dpgettext_noop("default", unquote(context), unquote(msgid))
+          unquote(__MODULE__).dpgettext_noop(unquote(domain), unquote(context), unquote(msgid))
         end
       end
 
@@ -147,9 +154,10 @@ defmodule Gettext.Compiler do
       end
 
       defmacro pngettext_noop(msgctxt, msgid, msgid_plural) do
+        domain = __gettext__(:default_domain)
         quote do
           unquote(__MODULE__).dpngettext_noop(
-            "default",
+            unquote(domain),
             unquote(msgctxt),
             unquote(msgid),
             unquote(msgid_plural)
@@ -158,9 +166,10 @@ defmodule Gettext.Compiler do
       end
 
       defmacro ngettext_noop(msgid, msgid_plural) do
+        domain = __gettext__(:default_domain)
         quote do
           unquote(__MODULE__).dpngettext_noop(
-            "default",
+            unquote(domain),
             nil,
             unquote(msgid),
             unquote(msgid_plural)
@@ -190,9 +199,10 @@ defmodule Gettext.Compiler do
       end
 
       defmacro pgettext(msgctxt, msgid, bindings \\ Macro.escape(%{})) do
+        domain = __gettext__(:default_domain)
         quote do
           unquote(__MODULE__).dpgettext(
-            "default",
+            unquote(domain),
             unquote(msgctxt),
             unquote(msgid),
             unquote(bindings)
@@ -201,8 +211,9 @@ defmodule Gettext.Compiler do
       end
 
       defmacro gettext(msgid, bindings \\ Macro.escape(%{})) do
+        domain = __gettext__(:default_domain)
         quote do
-          unquote(__MODULE__).dpgettext("default", nil, unquote(msgid), unquote(bindings))
+          unquote(__MODULE__).dpgettext(unquote(domain), nil, unquote(msgid), unquote(bindings))
         end
       end
 
@@ -242,9 +253,10 @@ defmodule Gettext.Compiler do
       end
 
       defmacro ngettext(msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
+        domain = __gettext__(:default_domain)
         quote do
           unquote(__MODULE__).dpngettext(
-            "default",
+            unquote(domain),
             nil,
             unquote(msgid),
             unquote(msgid_plural),
@@ -255,9 +267,10 @@ defmodule Gettext.Compiler do
       end
 
       defmacro pngettext(msgctxt, msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
+        domain = __gettext__(:default_domain)
         quote do
           unquote(__MODULE__).dpngettext(
-            "default",
+            unquote(domain),
             unquote(msgctxt),
             unquote(msgid),
             unquote(msgid_plural),

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -39,6 +39,7 @@ defmodule Gettext.Compiler do
 
     default_locale =
       opts[:default_locale] || quote(do: Application.fetch_env!(:gettext, :default_locale))
+
     default_domain = opts[:default_domain] || @default_domain
 
     Module.put_attribute(env.module, :gettext_default_domain, default_domain)
@@ -108,6 +109,7 @@ defmodule Gettext.Compiler do
 
       defmacro gettext_noop(msgid) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpgettext_noop(unquote(domain), nil, unquote(msgid))
         end
@@ -115,6 +117,7 @@ defmodule Gettext.Compiler do
 
       defmacro pgettext_noop(msgid, context) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpgettext_noop(unquote(domain), unquote(context), unquote(msgid))
         end
@@ -155,6 +158,7 @@ defmodule Gettext.Compiler do
 
       defmacro pngettext_noop(msgctxt, msgid, msgid_plural) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpngettext_noop(
             unquote(domain),
@@ -167,6 +171,7 @@ defmodule Gettext.Compiler do
 
       defmacro ngettext_noop(msgid, msgid_plural) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpngettext_noop(
             unquote(domain),
@@ -200,6 +205,7 @@ defmodule Gettext.Compiler do
 
       defmacro pgettext(msgctxt, msgid, bindings \\ Macro.escape(%{})) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpgettext(
             unquote(domain),
@@ -212,6 +218,7 @@ defmodule Gettext.Compiler do
 
       defmacro gettext(msgid, bindings \\ Macro.escape(%{})) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpgettext(unquote(domain), nil, unquote(msgid), unquote(bindings))
         end
@@ -254,6 +261,7 @@ defmodule Gettext.Compiler do
 
       defmacro ngettext(msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpngettext(
             unquote(domain),
@@ -268,6 +276,7 @@ defmodule Gettext.Compiler do
 
       defmacro pngettext(msgctxt, msgid, msgid_plural, n, bindings \\ Macro.escape(%{})) do
         domain = __gettext__(:default_domain)
+
         quote do
           unquote(__MODULE__).dpngettext(
             unquote(domain),

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -23,6 +23,10 @@ defmodule GettextTest.TranslatorWithCustomPluralForms do
   use Gettext, otp_app: :test_application, plural_forms: Plural
 end
 
+defmodule GettextTest.TranslatorWithDefaultDomain do
+  use Gettext, otp_app: :test_application, default_domain: "errors"
+end
+
 defmodule GettextTest.HandleMissingTranslation do
   use Gettext, otp_app: :test_application
 
@@ -46,11 +50,13 @@ defmodule GettextTest do
   alias GettextTest.TranslatorWithCustomPriv
   alias GettextTest.TranslatorWithAllowedLocales
   alias GettextTest.TranslatorWithCustomPluralForms
+  alias GettextTest.TranslatorWithDefaultDomain
   alias GettextTest.HandleMissingTranslation
 
   require Translator
   require TranslatorWithCustomPriv
   require TranslatorWithAllowedLocales
+  require TranslatorWithDefaultDomain
 
   test "the default locale is \"en\"" do
     assert Gettext.get_locale() == "en"
@@ -107,6 +113,11 @@ defmodule GettextTest do
     assert TranslatorWithCustomPriv.__gettext__(:otp_app) == :test_application
   end
 
+  test "__gettext__(:default_domain): returns the default domain for the given backend" do
+    assert Translator.__gettext__(:default_domain) == "default"
+    assert TranslatorWithDefaultDomain.__gettext__(:default_domain) == "errors"
+  end
+
   test "found translations return {:ok, translation}" do
     assert Translator.lgettext("it", "default", nil, "Hello world", %{}) == {:ok, "Ciao mondo"}
 
@@ -139,6 +150,13 @@ defmodule GettextTest do
 
     assert TranslatorWithCustomPriv.lgettext("it", "errors", nil, "Invalid email address", %{}) ==
              {:ok, "Indirizzo email non valido"}
+  end
+
+  test "a custom default_domain can be set for a backend" do
+    alias TranslatorWithDefaultDomain, as: T
+    Gettext.put_locale("it")
+    assert T.gettext("Invalid email address") == "Indirizzo email non valido"
+    assert T.gettext("Hello world") == "Hello world"
   end
 
   test "allowed_locales ignores other locales" do


### PR DESCRIPTION
Resolves #253

A given backend can be configured to have a default domain with the option
`:default_domain`, as in:

```elixir
config :gettext, MyApp.Gettext, default_domain: "messages"

defmodule MyApp.Gettext do
  use Gettext, otp_app: :my_app, default_domain: "messages"
end
```

When applied, this means that instead of `MyApp.Gettext.gettext("foo")` being
equivalent to `MyApp.Gettext.dgettext("default", "foo")`, it is now equivalent
to `MyApp.Gettext.gettext("messages", "foo")`.