### PR TITLE
Improve parallelism when compiling modules

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -387,12 +387,15 @@ defmodule Gettext.Compiler do
             %{},
             &compile_parallel_po_file(env, &1, &2, plural_mod)
           )
+
         {quoted, locale}
       end)
       |> Enum.map(fn {quoted, locale} ->
-        task = Kernel.ParallelCompiler.async(fn ->
-                create_locale_module(env, hd(Enum.to_list(locale)))
-              end)
+        task =
+          Kernel.ParallelCompiler.async(fn ->
+            create_locale_module(env, hd(Enum.to_list(locale)))
+          end)
+
         {task, quoted}
       end)
       |> Enum.map(fn {task, quoted} ->

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -399,15 +399,6 @@ defmodule Gettext.Compiler do
         Task.await(task, :infinity)
         quoted
       end)
-
-      #{quoted, locales} =
-        #Enum.map_reduce(known_po_files, %{}, &compile_parallel_po_file(env, &1, &2, plural_mod))
-
-      #locales
-      #|> Enum.map(&Kernel.ParallelCompiler.async(fn -> create_locale_module(env, &1) end))
-      #|> Enum.each(&Task.await(&1, :infinity))
-
-      #quoted
     else
       Enum.map(known_po_files, &compile_serial_po_file(env, &1, plural_mod))
     end


### PR DESCRIPTION
Instead of loading everything into memory at once, I'm compiling the locales one by one in a stream, and then passing it to the parallel compiler.

In a project of mine, compile time goes from 2m 11s to 1m25s.
Memory consumption also goes down, from 3.35G to 2.56G

I'm aware the resulting code is not the most elegant. If you have ideas of better takes to do the same, I'm happy to try them. This is the minimal version that accomplishes the task of reducing memory and run time. Other takes would require more involved changes