### PR TITLE
Binding interpolation with string keys

### DIFF
--- a/lib/gettext/interpolation.ex
+++ b/lib/gettext/interpolation.ex
@@ -20,17 +20,19 @@ defmodule Gettext.Interpolation do
       ["Empties %{} stay empty"]
 
   """
+  def to_interpolatable(string, opts \\ [mode: :atom])
+
   @spec to_interpolatable(String.t()) :: interpolatable
-  def to_interpolatable(string) do
+  def to_interpolatable(string, opts) do
     start_pattern = :binary.compile_pattern("%{")
     end_pattern = :binary.compile_pattern("}")
 
     string
-    |> to_interpolatable(_current = "", _acc = [], start_pattern, end_pattern)
+    |> to_interpolatable(_current = "", _acc = [], start_pattern, end_pattern, opts)
     |> Enum.reverse()
   end
 
-  defp to_interpolatable(string, current, acc, start_pattern, end_pattern) do
+  defp to_interpolatable(string, current, acc, start_pattern, end_pattern, opts) do
     case :binary.split(string, start_pattern) do
       # If we have one element, no %{ was found so this is the final part of the
       # string.
@@ -41,7 +43,7 @@ defmodule Gettext.Interpolation do
       # append %{} to the current string and keep going.
       [before, "}" <> rest] ->
         new_current = current <> before <> "%{}"
-        to_interpolatable(rest, new_current, acc, start_pattern, end_pattern)
+        to_interpolatable(rest, new_current, acc, start_pattern, end_pattern, opts)
 
       # Otherwise, we found the start of a binding.
       [before, binding_and_rest] ->
@@ -55,8 +57,18 @@ defmodule Gettext.Interpolation do
           # This is the case where we found a binding, so we put it in the acc
           # and keep going.
           [binding, rest] ->
-            new_acc = [String.to_atom(binding) | prepend_if_not_empty(before, acc)]
-            to_interpolatable(rest, "", new_acc, start_pattern, end_pattern)
+            mode = Keyword.get(opts, :mode)
+
+            binding =
+              if mode == :atom do
+                String.to_atom(binding)
+              else
+                "%{#{binding}}"
+              end
+
+            new_acc = [binding | prepend_if_not_empty(before, acc)]
+
+            to_interpolatable(rest, "", new_acc, start_pattern, end_pattern, opts)
         end
     end
   end
@@ -89,31 +101,57 @@ defmodule Gettext.Interpolation do
   """
   @spec interpolate(interpolatable, map) ::
           {:ok, String.t()} | {:missing_bindings, String.t(), [atom]}
-  def interpolate(interpolatable, bindings)
+  def interpolate(interpolatable, bindings, opts \\ [mode: :atom])
+
+  def interpolate(interpolatable, bindings, opts)
       when is_list(interpolatable) and is_map(bindings) do
-    interpolate(interpolatable, bindings, [], [])
+    interpolate(interpolatable, bindings, [], [], opts)
   end
 
-  defp interpolate([string | segments], bindings, strings, missing) when is_binary(string) do
-    interpolate(segments, bindings, [string | strings], missing)
-  end
+  defp interpolate([string | segments], bindings, strings, missing, opts)
+       when is_binary(string) do
+    if Keyword.get(opts, :mode) == :atom do
+      interpolate(segments, bindings, [string | strings], missing, opts)
+    else
+      clean_string =
+        if String.starts_with?(string, "%{") do
+          "%{" <> dirty_string = string
+          String.trim_trailing(dirty_string, "}")
+        end
 
-  defp interpolate([atom | segments], bindings, strings, missing) when is_atom(atom) do
-    case bindings do
-      %{^atom => value} ->
-        interpolate(segments, bindings, [to_string(value) | strings], missing)
+      case bindings do
+        %{^clean_string => value} ->
+          interpolate(segments, bindings, [to_string(value) | strings], missing, opts)
 
-      %{} ->
-        strings = ["%{" <> Atom.to_string(atom) <> "}" | strings]
-        interpolate(segments, bindings, strings, [atom | missing])
+        %{} ->
+          if is_nil(clean_string) do
+            strings = ["#{string}" | strings]
+
+            interpolate(segments, bindings, strings, missing, opts)
+          else
+            strings = [string | strings]
+            interpolate(segments, bindings, strings, [clean_string | missing], opts)
+          end
+      end
     end
   end
 
-  defp interpolate([], _bindings, strings, []) do
+  defp interpolate([atom | segments], bindings, strings, missing, opts) when is_atom(atom) do
+    case bindings do
+      %{^atom => value} ->
+        interpolate(segments, bindings, [to_string(value) | strings], missing, opts)
+
+      %{} ->
+        strings = ["%{" <> Atom.to_string(atom) <> "}" | strings]
+        interpolate(segments, bindings, strings, [atom | missing], opts)
+    end
+  end
+
+  defp interpolate([], _bindings, strings, [], _opts) do
     {:ok, IO.iodata_to_binary(Enum.reverse(strings))}
   end
 
-  defp interpolate([], _bindings, strings, missing) do
+  defp interpolate([], _bindings, strings, missing, _opts) do
     missing = missing |> Enum.reverse() |> Enum.uniq()
     {:missing_bindings, IO.iodata_to_binary(Enum.reverse(strings)), missing}
   end

--- a/test/gettext/interpolation_test.exs
+++ b/test/gettext/interpolation_test.exs
@@ -3,39 +3,105 @@ defmodule Gettext.InterpolationTest do
   doctest Gettext.Interpolation
   alias Gettext.Interpolation
 
-  test "interpolate/2" do
-    interpolatable = Interpolation.to_interpolatable("%{a} %{b} %{c}")
+  describe "interpolate/2" do
+    test "with bindings with atom keys" do
+      interpolatable = Interpolation.to_interpolatable("%{a} %{b} %{c}")
 
-    assert Interpolation.interpolate(interpolatable, %{a: 1, b: :two, c: "thr ee"}) ==
-             {:ok, "1 two thr ee"}
+      assert Interpolation.interpolate(interpolatable, %{a: 1, b: :two, c: "thr ee"}) ==
+               {:ok, "1 two thr ee"}
 
-    assert Interpolation.interpolate(interpolatable, %{a: "a"}) ==
-             {:missing_bindings, "a %{b} %{c}", [:b, :c]}
+      assert Interpolation.interpolate(interpolatable, %{a: "a"}) ==
+               {:missing_bindings, "a %{b} %{c}", [:b, :c]}
 
-    interpolatable = Interpolation.to_interpolatable("%{a} %{a} %{a}")
+      interpolatable = Interpolation.to_interpolatable("%{a} %{a} %{a}")
 
-    assert Interpolation.interpolate(interpolatable, %{a: "foo"}) == {:ok, "foo foo foo"}
+      assert Interpolation.interpolate(interpolatable, %{a: "foo"}) == {:ok, "foo foo foo"}
 
-    assert Interpolation.interpolate(interpolatable, %{b: "bar"}) ==
-             {:missing_bindings, "%{a} %{a} %{a}", [:a]}
+      assert Interpolation.interpolate(interpolatable, %{b: "bar"}) ==
+               {:missing_bindings, "%{a} %{a} %{a}", [:a]}
+    end
+
+    test "with bindings with string keys" do
+      interpolatable = Interpolation.to_interpolatable("%{a} %{b} %{c}", mode: :string_keys)
+
+      assert Interpolation.interpolate(interpolatable, %{"a" => 1, "b" => :two, "c" => "thr ee"},
+               mode: :string_keys
+             ) == {:ok, "1 two thr ee"}
+
+      assert Interpolation.interpolate(interpolatable, %{"a" => "a"}, mode: :string_keys) ==
+               {:missing_bindings, "a %{b} %{c}", ["b", "c"]}
+
+      interpolatable = Interpolation.to_interpolatable("%{a} %{a} %{a}", mode: :string_keys)
+
+      assert Interpolation.interpolate(interpolatable, %{"a" => "foo"}, mode: :string_keys) ==
+               {:ok, "foo foo foo"}
+
+      assert Interpolation.interpolate(interpolatable, %{"b" => "bar"}, mode: :string_keys) ==
+               {:missing_bindings, "%{a} %{a} %{a}", ["a"]}
+    end
   end
 
-  test "to_interpolatable/1" do
-    assert Interpolation.to_interpolatable("Hello %{name}") == ["Hello ", :name]
-    assert Interpolation.to_interpolatable("%{solo}") == [:solo]
-    assert Interpolation.to_interpolatable("%{foo}%{bar} %{baz}") == [:foo, :bar, " ", :baz]
-    assert Interpolation.to_interpolatable("%{Your name} is cool!") == [:"Your name", " is cool!"]
-    assert Interpolation.to_interpolatable("foo %{} bar") == ["foo %{} bar"]
-    assert Interpolation.to_interpolatable("%{") == ["%{"]
-    assert Interpolation.to_interpolatable("abrupt ending %{") == ["abrupt ending %{"]
+  describe "to_interpolatable/1" do
+    test "expecting atom keys" do
+      assert Interpolation.to_interpolatable("Hello %{name}") == ["Hello ", :name]
+      assert Interpolation.to_interpolatable("%{solo}") == [:solo]
+      assert Interpolation.to_interpolatable("%{foo}%{bar} %{baz}") == [:foo, :bar, " ", :baz]
 
-    assert Interpolation.to_interpolatable("incomplete %{ and then some") ==
-             ["incomplete %{ and then some"]
+      assert Interpolation.to_interpolatable("%{Your name} is cool!") == [
+               :"Your name",
+               " is cool!"
+             ]
 
-    assert Interpolation.to_interpolatable("first empty %{} then %{ incomplete") ==
-             ["first empty %{} then %{ incomplete"]
+      assert Interpolation.to_interpolatable("foo %{} bar") == ["foo %{} bar"]
+      assert Interpolation.to_interpolatable("%{") == ["%{"]
+      assert Interpolation.to_interpolatable("abrupt ending %{") == ["abrupt ending %{"]
 
-    assert Interpolation.to_interpolatable("") == []
+      assert Interpolation.to_interpolatable("incomplete %{ and then some") ==
+               ["incomplete %{ and then some"]
+
+      assert Interpolation.to_interpolatable("first empty %{} then %{ incomplete") ==
+               ["first empty %{} then %{ incomplete"]
+
+      assert Interpolation.to_interpolatable("") == []
+    end
+
+    test "expecting string keys" do
+      assert Interpolation.to_interpolatable("Hello %{name}", mode: :string_keys) == [
+               "Hello ",
+               "%{name}"
+             ]
+
+      assert Interpolation.to_interpolatable("%{solo}", mode: :string_keys) == ["%{solo}"]
+
+      assert Interpolation.to_interpolatable("%{foo}%{bar} %{baz}", mode: :string_keys) == [
+               "%{foo}",
+               "%{bar}",
+               " ",
+               "%{baz}"
+             ]
+
+      assert Interpolation.to_interpolatable("%{Your name} is cool!", mode: :string_keys) == [
+               "%{Your name}",
+               " is cool!"
+             ]
+
+      assert Interpolation.to_interpolatable("foo %{} bar", mode: :string_keys) == ["foo %{} bar"]
+      assert Interpolation.to_interpolatable("%{", mode: :string_keys) == ["%{"]
+
+      assert Interpolation.to_interpolatable("abrupt ending %{", mode: :string_keys) == [
+               "abrupt ending %{"
+             ]
+
+      assert Interpolation.to_interpolatable("incomplete %{ and then some", mode: :string_keys) ==
+               ["incomplete %{ and then some"]
+
+      assert Interpolation.to_interpolatable("first empty %{} then %{ incomplete",
+               mode: :string_keys
+             ) ==
+               ["first empty %{} then %{ incomplete"]
+
+      assert Interpolation.to_interpolatable("", mode: :string_keys) == []
+    end
   end
 
   if :erlang.system_info(:otp_release) >= '20' do


### PR DESCRIPTION
Hi guys,

This is a super **work in progress** to get feedback from you folks.
It tries to address (partially for the moment) issue https://github.com/elixir-gettext/gettext/issues/266

For the bindings:

* I am introducing a `:mode` that it is `:atom` by default
* In `to_interpolatable` function I am marking (only in the case of non `:atom` maps) the binding with `%{}` since I did not found a way to determine the string binding

Currently this implementation is kind of dirty I know, I am open to feedback if this approach is worth to carry on.
I was thinking to add the `:mode` as a macro parameter in `compiler.ex` to be able to specify it (not in this PR yet)

Thanks a lot!