### PR TITLE
Change references from "country" to "territory"

### DIFF
--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -12,16 +12,16 @@ defmodule Gettext.Backend do
 
   For example, if something like this is called:
 
-      MyApp.Gettext.gettext("Hello %{name}, welcome to %{territory}", name: "Jane", territory: "Italy")
+      MyApp.Gettext.gettext("Hello %{name}, your favorite color is %{color}", name: "Jane", color: "blue")
 
   and our `it/LC_MESSAGES/default.po` looks like this:
 
-      msgid "Hello %{name}, welcome to %{territory}"
-      msgstr "Ciao %{name}, benvenuto in %{cowntry}" # (typo)
+      msgid "Hello %{name}, your favorite color is %{color}"
+      msgstr "Ciao %{name}, il tuo colore preferito è %{colour}" # (typo)
 
   then Gettext will call:
 
-      MyApp.Gettext.handle_missing_bindings(exception, "Ciao Jane, benvenuto in %{cowntry}")
+      MyApp.Gettext.handle_missing_bindings(exception, "Ciao Jane, il tuo colore preferito è %{colour}")
 
   where `exception` is a struct that looks like this:
 
@@ -29,8 +29,8 @@ defmodule Gettext.Backend do
         backend: MyApp.Gettext,
         domain: "default",
         locale: "it",
-        msgid: "Hello %{name}, welcome to %{territory}",
-        bindings: [:territory],
+        msgid: "Ciao %{name}, il tuo colore preferito è %{colour}",
+        bindings: [:colour],
       }
 
   The return value of the `c:handle_missing_bindings/2` callback is used as the

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -12,11 +12,11 @@ defmodule Gettext.Backend do
 
   For example, if something like this is called:
 
-      MyApp.Gettext.gettext("Hello %{name}, welcome to %{country}", name: "Jane", country: "Italy")
+      MyApp.Gettext.gettext("Hello %{name}, welcome to %{territory}", name: "Jane", territory: "Italy")
 
   and our `it/LC_MESSAGES/default.po` looks like this:
 
-      msgid "Hello %{name}, welcome to %{country}"
+      msgid "Hello %{name}, welcome to %{territory}"
       msgstr "Ciao %{name}, benvenuto in %{cowntry}" # (typo)
 
   then Gettext will call:
@@ -29,8 +29,8 @@ defmodule Gettext.Backend do
         backend: MyApp.Gettext,
         domain: "default",
         locale: "it",
-        msgid: "Hello %{name}, welcome to %{country}",
-        bindings: [:country],
+        msgid: "Hello %{name}, welcome to %{territory}",
+        bindings: [:territory],
       }
 
   The return value of the `c:handle_missing_bindings/2` callback is used as the

--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -88,16 +88,18 @@ defmodule Gettext.Plural do
   Trying to call `Gettext.Plural` functions with unknown locales will result in
   a `Gettext.Plural.UnknownLocaleError` exception.
 
-  ### Language and country
+  ### Language and territory
 
-  Often, a locale is composed as a language and country couple, such as
+  Often, a locale is composed as a language and territory couple, such as
   `en_US`. The default implementation for `Gettext.Plural` handles `xx_YY` by
   forwarding it to `xx` (except for *just Brazilian Portuguese*, `pt_BR`, which
   is not forwarded to `pt` as pluralization rules slightly differ). We treat the
-  underscore as a separator according to ISO 15897. Sometimes, a dash `-` is
-  used as a separator (for example, `en-US`): this is not forwarded to `en` in the
-  default `Gettext.Plural` (and it will raise an `Gettext.Plural.UnknownLocaleError`
-  exception).
+  underscore as a separator according to
+  [ISO 15897](https://en.wikipedia.org/wiki/ISO/IEC_15897). Sometimes, a dash `-` is
+  used as a separator (for example [BCP47](https://en.wikipedia.org/wiki/IETF_language_tag)
+  locales use this as in `en-US`): this is not forwarded to `en` in the default
+  `Gettext.Plural` (and it will raise an `Gettext.Plural.UnknownLocaleError` exception
+  if there are no translations for `en-US`).
 
   ## Examples
 
@@ -502,7 +504,7 @@ defmodule Gettext.Plural do
 
   # Match-all clause.
   def nplurals(locale) do
-    recall_if_country_or_raise(locale, &nplurals/1)
+    recall_if_territory_or_raise(locale, &nplurals/1)
   end
 
   # Plural form of groupable languages.
@@ -670,12 +672,12 @@ defmodule Gettext.Plural do
 
   # Match-all clause.
   def plural(locale, n) do
-    recall_if_country_or_raise(locale, &plural(&1, n))
+    recall_if_territory_or_raise(locale, &plural(&1, n))
   end
 
-  defp recall_if_country_or_raise(locale, fun) do
+  defp recall_if_territory_or_raise(locale, fun) do
     case String.split(locale, "_", parts: 2, trim: true) do
-      [lang, _country] -> fun.(lang)
+      [lang, _territory] -> fun.(lang)
       _other -> raise UnknownLocaleError, locale
     end
   end

--- a/test/gettext/plural_test.exs
+++ b/test/gettext/plural_test.exs
@@ -14,7 +14,7 @@ defmodule Gettext.PluralTest do
     assert plural("pt_BR", 1) == 0
   end
 
-  test "locale with a country" do
+  test "locale with a territory" do
     # The _XX in en_XX gets stripped and en_XX is pluralized as en.
     assert nplurals("en_XX") == nplurals("en")
     assert plural("en_XX", 100) == plural("en", 100)
@@ -25,7 +25,7 @@ defmodule Gettext.PluralTest do
     assert_raise UnknownLocaleError, message, fn -> nplurals("wat") end
     assert_raise UnknownLocaleError, message, fn -> plural("wat", 1) end
 
-    # This happens with dash as the country/locale separator
+    # This happens with dash as the territory/locale separator
     # (https://en.wikipedia.org/wiki/IETF_language_tag).
     message = ~r/unknown locale "en-us"/
     assert_raise UnknownLocaleError, message, fn -> nplurals("en-us") end


### PR DESCRIPTION
"country" refers to a political entity which can cause conflict when territories are disputed.

A list of disputed territories is available at https://en.wikipedia.org/wiki/List_of_territorial_disputes

This commit uses the term "territory" rather than "country" to reflect that locales serve a purpose
to reflect user preferences, not to express a political agreements.

* Annex A to ISO/IEC 15897:1998(E) also refers to "territory" for submissions.

* ISO3166 which lists "country codes" says for "TW" (Taiwan) that ISO recognises Taiwan as "Taiwan, Province of China". This view is not widely accepted by the people who live in Taiwan showing how challenging it is to reflect
both cultural preferences and manage political realities.

Using the term "territory" tends to nullify these issues and focus on the reason that a locale definition exists.

CLDR (https://cldr.unicode.org) uses the terms "territory" or "region" interchangeably for this reason.