### PR TITLE
Make dngettext/6 bindings optional

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -907,7 +907,7 @@ defmodule Gettext do
 
   """
   @spec dngettext(module, binary, binary, binary, non_neg_integer, bindings) :: binary
-  def dngettext(backend, domain, msgid, msgid_plural, n, bindings),
+  def dngettext(backend, domain, msgid, msgid_plural, n, bindings \\ %{}),
     do: dpngettext(backend, domain, nil, msgid, msgid_plural, n, bindings)
 
   @doc """

--- a/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/interpolations.po
+++ b/test/fixtures/test_application/priv/gettext/it/LC_MESSAGES/interpolations.po
@@ -9,6 +9,11 @@ msgid_plural "You have %{count} messages, %{name}"
 msgstr[0] "Hai un messaggio, %{name}"
 msgstr[1] "Hai %{count} messaggi, %{name}"
 
+msgid "Month"
+msgid_plural "%{count} months"
+msgstr[0] "Mese"
+msgstr[1] "%{count} mesi"
+
 msgctxt "test"
 msgid "You have one message, %{name}"
 msgid_plural "You have %{count} messages, %{name}"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -566,6 +566,13 @@ defmodule GettextTest do
              2,
              %{name: "James"}
            ) == "Hai 2 messaggi, James"
+
+    assert Translator.dngettext(
+             "interpolations",
+             "Month",
+             "%{count} months",
+             2
+           ) == "2 mesi"
   end
 
   @ngettext_msgid "One new email"
@@ -663,6 +670,9 @@ defmodule GettextTest do
 
     assert Gettext.dngettext(Translator, "interpolations", msgid, msgid_plural, 5, %{name: "Meg"}) ==
              "Hai 5 messaggi, Meg"
+
+    assert Gettext.dngettext(Translator, "interpolations", "Month", "%{count} months", 5) ==
+             "5 mesi"
   end
 
   test "dpngettext/6" do


### PR DESCRIPTION
According to [the examples](https://hexdocs.pm/gettext/Gettext.html#dngettext/6-examples) `dngettext/6`'s last argument `bindings` is supposed to be optional.
Please let me know If I need to leave the function as is and edit the examples instead.