### PR TITLE
Increase Mix.Tasks.Gettext.Merge task timeout.

### DIFF
--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -186,7 +186,7 @@ defmodule Mix.Tasks.Gettext.Merge do
     pot_dir
     |> Path.join("*.pot")
     |> Path.wildcard()
-    |> Task.async_stream(merger, ordered: false, timeout: 60_000)
+    |> Task.async_stream(merger, ordered: false, timeout: :infinity)
     |> Stream.run()
 
     warn_for_po_without_pot(po_dir, pot_dir)

--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -186,7 +186,7 @@ defmodule Mix.Tasks.Gettext.Merge do
     pot_dir
     |> Path.join("*.pot")
     |> Path.wildcard()
-    |> Task.async_stream(merger, ordered: false, timeout: 10_000)
+    |> Task.async_stream(merger, ordered: false, timeout: 60_000)
     |> Stream.run()
 
     warn_for_po_without_pot(po_dir, pot_dir)


### PR DESCRIPTION
Increasing the task timeout, necessary when project starts to get big !