### PR TITLE
Supress Warning "variable "bindings" is unused"

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -611,7 +611,7 @@ defmodule Gettext.Compiler do
               line: unquote(t.po_source_line)
         end
 
-      quote do
+      quote generated: true do
         Kernel.unquote(kind)(
           unquote(plural_fun)(
             unquote(msgctxt),


### PR DESCRIPTION
Suppresses warning:

```
warning: variable "bindings" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/hygeia_gettext.ex:1: HygeiaGettext.T_fr_default.fr_default_lngettext/5
```

This warning happens, because `clauses` can be an empty list. Therefore the variable is actually never used.