### PR TITLE
Fix failing test

### DIFF
--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -47,8 +47,6 @@ defmodule Mix.Tasks.Gettext.Extract do
     mix_config = Mix.Project.config()
     {opts, _} = OptionParser.parse!(args, switches: @switches)
     pot_files = extract(mix_config[:app], mix_config[:gettext] || [])
-    IO.inspect(pot_files, label: "pot_files")
-    IO.inspect(opts, label: "opts")
 
     if opts[:check_up_to_date] do
       run_up_to_date_check(pot_files)

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -47,6 +47,8 @@ defmodule Mix.Tasks.Gettext.Extract do
     mix_config = Mix.Project.config()
     {opts, _} = OptionParser.parse!(args, switches: @switches)
     pot_files = extract(mix_config[:app], mix_config[:gettext] || [])
+    IO.inspect(pot_files, label: "pot_files")
+    IO.inspect(opts, label: "opts")
 
     if opts[:check_up_to_date] do
       run_up_to_date_check(pot_files)
@@ -104,8 +106,8 @@ defmodule Mix.Tasks.Gettext.Extract do
     # "compile" is a no-op and running "compile.elixir" will work because we
     # manually reenabled it.
     Mix.Task.reenable("compile.elixir")
-    Mix.Task.run("compile")
-    Mix.Task.run("compile.elixir")
+    Mix.Task.run("compile", ["--force"])
+    Mix.Task.run("compile.elixir", ["--force"])
   end
 
   defp make_old_if_exists(path) do

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -107,7 +107,7 @@ defmodule Mix.Tasks.Gettext.Extract do
     # manually reenabled it.
     Mix.Task.reenable("compile.elixir")
     Mix.Task.run("compile", ["--force"])
-    Mix.Task.run("compile.elixir", ["--force"])
+    Mix.Task.run("compile.elixir")
   end
 
   defp make_old_if_exists(path) do

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -106,8 +106,8 @@ defmodule Mix.Tasks.Gettext.Extract do
     # "compile" is a no-op and running "compile.elixir" will work because we
     # manually reenabled it.
     Mix.Task.reenable("compile.elixir")
-    Mix.Task.run("compile", ["--force"])
-    Mix.Task.run("compile.elixir")
+    Mix.Task.run("compile")
+    Mix.Task.run("compile.elixir", ["--force"])
   end
 
   defp make_old_if_exists(path) do


### PR DESCRIPTION
This was the failure:

```
  1) test extracting and extracting with --merge (Mix.Tasks.Gettext.ExtractTest)
     test/mix/tasks/gettext.extract_test.exs:19
     Assertion with == failed
     code:  assert read_file("priv/gettext/it/LC_MESSAGES/my_domain.po") == "#, elixir-format, ex-autogen\n#: lib/other.ex:3\nmsgid \"other\"\nmsgstr \"\"\n"
     left:  ""
     right: "#, elixir-format, ex-autogen\n#: lib/other.ex:3\nmsgid \"other\"\nmsgstr \"\"\n"
     stacktrace:
       test/mix/tasks/gettext.extract_test.exs:62: (test)
```

It was caused by the second file written in the test not being recompiled.

cc @josevalim do you know why changing the manifests in `gettext.extract` was not enough, and I had to use `--force`? Did something change in Elixir itself?