### PR TITLE
Fix typo: `deprecatead` to `deprecated`

### DIFF
--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -371,7 +371,7 @@ defmodule Gettext.Compiler do
     opts =
       if opts[:one_module_per_locale] do
         IO.warn(
-          ":one_module_per_locale is deprecatead, please use split_module_by: [:locale] instead"
+          ":one_module_per_locale is deprecated, please use split_module_by: [:locale] instead"
         )
 
         Keyword.put_new(opts, :split_module_by, [:locale])


### PR DESCRIPTION
This fixes a simple spelling mistake.