### PR TITLE
Pass msgctxt into handling missing translation functions

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -631,6 +631,22 @@ defmodule Gettext do
       end
 
       defoverridable handle_missing_translation: 4, handle_missing_plural_translation: 6
+
+      def handle_missing_translation(locale, domain, msgctxt, msgid, bindings),
+        do: handle_missing_translation(locale, domain, msgid, bindings)
+
+      def handle_missing_plural_translation(
+            locale,
+            domain,
+            msgctxt,
+            msgid,
+            msgid_plural,
+            n,
+            bindings
+          ),
+          do: handle_missing_plural_translation(locale, domain, msgid, msgid_plural, n, bindings)
+
+      defoverridable handle_missing_translation: 5, handle_missing_plural_translation: 7
     end
   end
 

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -70,6 +70,25 @@ defmodule Gettext.Backend do
   @callback handle_missing_translation(
               Gettext.locale(),
               domain :: String.t(),
+              msgctxt :: String.t(),
+              msgid :: String.t(),
+              bindings :: map()
+            ) ::
+              {:ok, String.t()} | {:default, String.t()} | {:missing_bindings, String.t(), [atom]}
+
+  @doc """
+  Fallback handling for missing translations.
+
+  Same as `c:handle_missing_translation/5`, but without msgctxt. This is kept
+  for compatibility with older versions of this library.
+
+  The default implementation of `c:handle_missing_translation/5` will call this
+  function, so users implementing the 4-argument callback will still get the same
+  results. However, they are encouraged to switch to the new 5-argument version.
+  """
+  @callback handle_missing_translation(
+              Gettext.locale(),
+              domain :: String.t(),
               msgid :: String.t(),
               bindings :: map()
             ) ::
@@ -78,8 +97,29 @@ defmodule Gettext.Backend do
   @doc """
   Default handling for plural translations with a missing translation.
 
-  Same as `c:handle_missing_translation/4`, but for plural translations.
+  Same as `c:handle_missing_translation/5`, but for plural translations.
   In this case, `n` is the number used for pluralizing the translated string.
+  """
+  @callback handle_missing_plural_translation(
+              Gettext.locale(),
+              domain :: String.t(),
+              msgctxt :: String.t(),
+              msgid :: String.t(),
+              msgid_plural :: String.t(),
+              n :: non_neg_integer(),
+              bindings :: map()
+            ) ::
+              {:ok, String.t()} | {:default, String.t()} | {:missing_bindings, String.t(), [atom]}
+
+  @doc """
+  Fallback handling for missing translations.
+
+  Same as `c:handle_missing_plural_translation/7`, but without msgctxt. This is kept
+  for compatibility with older versions of this library.
+
+  The default implementation of `c:handle_missing_plural_translation/7` will call this
+  function, so users implementing the 6-argument callback will still get the same
+  results. However, they are encouraged to switch to the new 7-argument version.
   """
   @callback handle_missing_plural_translation(
               Gettext.locale(),

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -66,29 +66,15 @@ defmodule Gettext.Backend do
   customize the default to, for example, pick the translation from the
   default locale. The important is to return `:default` instead of `:ok`
   whenever the result does not quite match the requested locale.
+
+  Earlier versions of this library provided a callback without msgctxt.
+  Users implementing that callback will still get the same results,
+  but they are encouraged to switch to the new 5-argument version.
   """
   @callback handle_missing_translation(
               Gettext.locale(),
               domain :: String.t(),
               msgctxt :: String.t(),
-              msgid :: String.t(),
-              bindings :: map()
-            ) ::
-              {:ok, String.t()} | {:default, String.t()} | {:missing_bindings, String.t(), [atom]}
-
-  @doc """
-  Fallback handling for missing translations.
-
-  Same as `c:handle_missing_translation/5`, but without msgctxt. This is kept
-  for compatibility with older versions of this library.
-
-  The default implementation of `c:handle_missing_translation/5` will call this
-  function, so users implementing the 4-argument callback will still get the same
-  results. However, they are encouraged to switch to the new 5-argument version.
-  """
-  @callback handle_missing_translation(
-              Gettext.locale(),
-              domain :: String.t(),
               msgid :: String.t(),
               bindings :: map()
             ) ::
@@ -99,31 +85,15 @@ defmodule Gettext.Backend do
 
   Same as `c:handle_missing_translation/5`, but for plural translations.
   In this case, `n` is the number used for pluralizing the translated string.
+
+  Earlier versions of this library provided a callback without msgctxt.
+  Users implementing that callback will still get the same results,
+  but they are encouraged to switch to the new 7-argument version.
   """
   @callback handle_missing_plural_translation(
               Gettext.locale(),
               domain :: String.t(),
               msgctxt :: String.t(),
-              msgid :: String.t(),
-              msgid_plural :: String.t(),
-              n :: non_neg_integer(),
-              bindings :: map()
-            ) ::
-              {:ok, String.t()} | {:default, String.t()} | {:missing_bindings, String.t(), [atom]}
-
-  @doc """
-  Fallback handling for missing translations.
-
-  Same as `c:handle_missing_plural_translation/7`, but without msgctxt. This is kept
-  for compatibility with older versions of this library.
-
-  The default implementation of `c:handle_missing_plural_translation/7` will call this
-  function, so users implementing the 6-argument callback will still get the same
-  results. However, they are encouraged to switch to the new 7-argument version.
-  """
-  @callback handle_missing_plural_translation(
-              Gettext.locale(),
-              domain :: String.t(),
               msgid :: String.t(),
               msgid_plural :: String.t(),
               n :: non_neg_integer(),

--- a/lib/gettext/compiler.ex
+++ b/lib/gettext/compiler.ex
@@ -60,10 +60,19 @@ defmodule Gettext.Compiler do
 
       # Catch-all clauses.
       def lgettext(locale, domain, msgctxt, msgid, bindings),
-        do: handle_missing_translation(locale, domain, msgid, bindings)
+        do: handle_missing_translation(locale, domain, msgctxt, msgid, bindings)
 
       def lngettext(locale, domain, msgctxt, msgid, msgid_plural, n, bindings),
-        do: handle_missing_plural_translation(locale, domain, msgid, msgid_plural, n, bindings)
+        do:
+          handle_missing_plural_translation(
+            locale,
+            domain,
+            msgctxt,
+            msgid,
+            msgid_plural,
+            n,
+            bindings
+          )
     end
   end
 


### PR DESCRIPTION
To resolve msgctxt not being passed into the fallback function,
we added new callbacks handle_missing_translation/5 and
handle_missing_plural_translation/7 that will get msgctxt.
The default implementations for these two functions call the
old versions respectively, so users implementing the old callbacks
still get the same result.

BUG: https://github.com/elixir-gettext/gettext/issues/303