### PR TITLE
Uniq comments for same translation

### DIFF
--- a/lib/gettext/extractor_agent.ex
+++ b/lib/gettext/extractor_agent.ex
@@ -75,6 +75,6 @@ defmodule Gettext.ExtractorAgent do
   defp merge_translations(t1, t2) do
     t1
     |> Map.put(:references, t1.references ++ t2.references)
-    |> Map.put(:extracted_comments, t1.extracted_comments ++ t2.extracted_comments)
+    |> Map.put(:extracted_comments, Enum.uniq(t1.extracted_comments ++ t2.extracted_comments))
   end
 end

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -272,9 +272,12 @@ defmodule Gettext.ExtractorTest do
       def bar do
         gettext_comment("some comment")
         gettext_comment("some other comment")
+        gettext_comment("repeated comment")
         gettext("foo")
         dngettext("errors", "one error", "%{count} errors", 2)
         gettext_comment("one more comment")
+        gettext_comment("repeated comment")
+        gettext_comment("repeated comment")
         gettext("foo")
         Gettext.ExtractorTest.MyOtherGettext.dgettext("greetings", "hi")
         pgettext("test", "context based translation")
@@ -292,15 +295,16 @@ defmodule Gettext.ExtractorTest do
 
        #. some comment
        #. some other comment
+       #. repeated comment
        #. one more comment
        #, elixir-autogen, elixir-format
-       #: foo.ex:16
-       #: foo.ex:19
+       #: foo.ex:17
+       #: foo.ex:22
        msgid "foo"
        msgstr ""
 
        #, elixir-autogen, elixir-format
-       #: foo.ex:21
+       #: foo.ex:24
        msgctxt "test"
        msgid "context based translation"
        msgstr ""
@@ -311,7 +315,7 @@ defmodule Gettext.ExtractorTest do
        msgstr ""
 
        #, elixir-autogen, elixir-format
-       #: foo.ex:17
+       #: foo.ex:18
        msgid "one error"
        msgid_plural "%{count} errors"
        msgstr[0] ""
@@ -323,7 +327,7 @@ defmodule Gettext.ExtractorTest do
        msgstr ""
 
        #, elixir-autogen, elixir-format
-       #: foo.ex:20
+       #: foo.ex:23
        msgid "hi"
        msgstr ""
        """}


### PR DESCRIPTION
Solves https://github.com/elixir-gettext/gettext/issues/308

Distinct comments for a same Gettext text on extraction, so a `gettext_comment/1` can be added into multiple places inside one or more apps, without duplications at the final `.pot` file.