### PR TITLE
Save previous message for fuzzy matches

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -606,6 +606,10 @@ defmodule Gettext do
       If `:mark_as_obsolete`, messages are kept and marked as obsolete.
       If `:delete`, obsolete messages are deleted. Defaults to `:delete`.
 
+    * `:store_previous_message_on_fuzzy_match` - a boolean that controls
+      wether to store the previous message text in case of a fuzzy match.
+      Defaults to `false`.
+
   """
 
   defmodule Error do

--- a/lib/gettext/merger.ex
+++ b/lib/gettext/merger.ex
@@ -90,6 +90,16 @@ defmodule Gettext.Merger do
               {:matched, match, fuzzy_merged} ->
                 stats_acc = update_in(stats_acc.fuzzy_matches, &(&1 + 1))
                 unused = Map.delete(unused, Message.key(match))
+
+                fuzzy_merged =
+                  if Keyword.get(opts, :store_previous_message_on_fuzzy_match, false) do
+                    Map.update!(fuzzy_merged, :previous_messages, fn previous ->
+                      Enum.uniq_by(previous ++ [match], &Message.key/1)
+                    end)
+                  else
+                    fuzzy_merged
+                  end
+
                 {fuzzy_merged, {stats_acc, unused}}
 
               :nomatch ->

--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -102,6 +102,9 @@ defmodule Mix.Tasks.Gettext.Merge do
       If `mark_as_obsolete`, messages are kept and marked as obsolete.
       If `delete`, obsolete messages are deleted. Defaults to `delete`.
 
+    * `--store-previous-message-on-fuzzy-match` - controls if the previous
+      messages are recorded on fuzzy matches. Is off by default.
+
   """
 
   alias Expo.PO
@@ -114,7 +117,8 @@ defmodule Mix.Tasks.Gettext.Merge do
     fuzzy: :boolean,
     fuzzy_threshold: :float,
     plural_forms: :integer,
-    on_obsolete: :string
+    on_obsolete: :string,
+    store_previous_message_on_fuzzy_match: :boolean
   ]
 
   def run(args) do
@@ -265,7 +269,14 @@ defmodule Mix.Tasks.Gettext.Merge do
   defp validate_merging_opts!(opts, gettext_config) do
     opts =
       opts
-      |> Keyword.take([:fuzzy, :fuzzy_threshold, :plural_forms, :on_obsolete])
+      |> Keyword.take([
+        :fuzzy,
+        :fuzzy_threshold,
+        :plural_forms,
+        :on_obsolete,
+        :store_previous_message_on_fuzzy_match
+      ])
+      |> Keyword.put_new(:store_previous_message_on_fuzzy_match, false)
       |> Keyword.put_new(:fuzzy, true)
       |> Keyword.put_new_lazy(:fuzzy_threshold, fn ->
         gettext_config[:fuzzy_threshold] || @default_fuzzy_threshold

--- a/test/mix/tasks/gettext.merge_test.exs
+++ b/test/mix/tasks/gettext.merge_test.exs
@@ -170,6 +170,32 @@ defmodule Mix.Tasks.Gettext.MergeTest do
     assert String.starts_with?(new_po, "## \"msgid\"s in this file come from POT")
   end
 
+  test "enabling --store-previous-message-on-fuzzy-match stores previous message" do
+    write_file("default.pot", """
+    msgid "Hello Worlds"
+    msgstr ""
+    """)
+
+    write_file("it/LC_MESSAGES/default.po", """
+    msgid "Hello World"
+    msgstr ""
+    """)
+
+    output =
+      capture_io(fn ->
+        run([@priv_path, "--locale", "it", "--store-previous-message-on-fuzzy-match"])
+      end)
+
+    assert output =~ "Wrote tmp/gettext.merge/it/LC_MESSAGES/default.po"
+
+    assert read_file("it/LC_MESSAGES/default.po") == """
+           #, fuzzy
+           #| msgid "Hello World"
+           msgid "Hello Worlds"
+           msgstr ""
+           """
+  end
+
   test "passing a dir and a --locale opt will update/create PO files in the locale dir with custom plural forms" do
     write_file("new.pot", """
     msgid "new"


### PR DESCRIPTION
Should this be the default behavior or hidden behind a flag?