### PR TITLE
Fix up-to-date check in extractor

### DIFF
--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -208,7 +208,11 @@ defmodule Gettext.Extractor do
     # then we can take advantage of Map.merge/3 to find files that we have to
     # update, delete, or add.
     pot_files = Map.new(pot_files, &{&1, :existing})
-    po_structs = Map.new(po_structs)
+
+    po_structs =
+      Map.new(po_structs, fn {path, struct} ->
+        {path, Merger.prune_references(struct, gettext_config)}
+      end)
 
     # After Map.merge/3, we have something like:
     #   %{path => {:merged, :unchanged | %Messages{}}, path => %Messages{}, path => :existing}
@@ -217,7 +221,7 @@ defmodule Gettext.Extractor do
     Map.merge(pot_files, po_structs, &merge_existing_and_extracted(&1, &2, &3, gettext_config))
     |> Enum.map(&tag_files(&1, gettext_config))
     |> Enum.reject(&match?({_, {_, :unchanged}}, &1))
-    |> Enum.map(&dump_tagged_file(&1, gettext_config))
+    |> Enum.map(&dump_tagged_file/1)
   end
 
   # This function is called by merge_pot_files/2 as the function passed to
@@ -267,8 +271,7 @@ defmodule Gettext.Extractor do
   # This function "dumps" merged files and unmerged files without any changes,
   # and dumps new POT files adding an informative comment to them. This doesn't
   # write anything to disk, it just returns `{path, contents}` tuples.
-  defp dump_tagged_file({path, {_tag, new_po}}, gettext_config),
-    do: {path, new_po |> Merger.prune_references(gettext_config) |> PO.compose()}
+  defp dump_tagged_file({path, {_tag, po}}), do: {path, PO.compose(po)}
 
   defp prune_unmerged(path, gettext_config) do
     merge_or_unchanged(path, %Messages{messages: []}, gettext_config)

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -79,12 +79,9 @@ defmodule Mix.Tasks.Gettext.Extract do
   end
 
   defp run_up_to_date_check(pot_files) do
-    not_extracted_paths =
-      for {path, contents} <- pot_files,
-          not File.exists?(path) or File.read!(path) != contents,
-          do: path
+    not_extracted_paths = for {path, _contents} <- pot_files, do: path
 
-    if not_extracted_paths == [] do
+    if pot_files == [] do
       :ok
     else
       Mix.raise("""

--- a/test/mix/tasks/gettext.extract_test.exs
+++ b/test/mix/tasks/gettext.extract_test.exs
@@ -105,6 +105,31 @@ defmodule Mix.Tasks.Gettext.ExtractTest do
     end)
   end
 
+  test "--check-up-to-date should pass if nothing changed" do
+    create_test_mix_file(write_reference_comments: false)
+
+    write_file("lib/my_app.ex", """
+    defmodule MyApp.Gettext do
+      use Gettext, otp_app: :my_app
+    end
+
+    defmodule MyApp do
+      require MyApp.Gettext
+      def foo(), do: MyApp.Gettext.gettext("hello")
+    end
+    """)
+
+    capture_io(fn ->
+      Mix.Project.in_project(:my_app, tmp_path("/"), fn _module ->
+        run([])
+      end)
+
+      Mix.Project.in_project(:my_app, tmp_path("/"), fn _module ->
+        run(["--check-up-to-date"])
+      end)
+    end)
+  end
+
   test "--check-up-to-date should fail if POT files are outdated" do
     create_test_mix_file()
 
@@ -157,13 +182,13 @@ defmodule Mix.Tasks.Gettext.ExtractTest do
     end)
   end
 
-  defp create_test_mix_file do
+  defp create_test_mix_file(gettext_config \\ []) do
     write_file("mix.exs", """
     defmodule MyApp.MixProject do
       use Mix.Project
 
       def project() do
-        [app: :my_app, version: "0.1.0"]
+        [app: :my_app, version: "0.1.0", gettext: #{inspect(gettext_config)}]
       end
 
       def application() do

--- a/test/mix/tasks/gettext.extract_test.exs
+++ b/test/mix/tasks/gettext.extract_test.exs
@@ -12,8 +12,11 @@ defmodule Mix.Tasks.Gettext.ExtractTest do
   end
 
   setup do
-    File.rm_rf!(@priv_path)
-    :ok
+    File.rm_rf!(tmp_path("/"))
+
+    on_exit(fn ->
+      File.rm_rf!(tmp_path("/"))
+    end)
   end
 
   test "extracting and extracting with --merge" do


### PR DESCRIPTION
I can't come up with a small test-case. Without it the check fails in one of my applications because `contents` is `iodata` and not a string.

Fixes #334