### PR TITLE
Supply plurals forms header to Gettext.Plural callbacks

### DIFF
--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -76,8 +76,8 @@ defmodule Mix.Tasks.Gettext.Merge do
   by checking the value of `nplurals` in the `Plural-Forms` header in the existing `.po` file. If
   a `.po` file doesn't already exist and Gettext is creating a new one or if the `Plural-Forms`
   header is not in the `.po` file, Gettext will use the number of plural forms that
-  `Gettext.Plural` returns for the locale of the file being created. The number of plural forms
-  can be forced through the `--plural-forms` option (see below).
+  `Gettext.Plural` returns for the locale of the file being created. The content of the plural forms
+  header can be forced through the `--plural-forms-header` option (see below).
 
   ## Options
 
@@ -98,6 +98,10 @@ defmodule Mix.Tasks.Gettext.Merge do
       new messages in the target PO files will have this number of empty
       plural forms. See the "Plural forms" section above.
 
+    * `--plural-forms-header` - `Plural-Forms` header content as string.
+      If this is passed, new messages in the target PO files will have this
+      number of empty plural forms. See the "Plural forms" section above.
+
     * `--on-obsolete` - controls what happens when obsolete messages are found.
       If `mark_as_obsolete`, messages are kept and marked as obsolete.
       If `delete`, obsolete messages are deleted. Defaults to `delete`.
@@ -117,6 +121,7 @@ defmodule Mix.Tasks.Gettext.Merge do
     fuzzy: :boolean,
     fuzzy_threshold: :float,
     plural_forms: :integer,
+    plural_forms_header: :string,
     on_obsolete: :string,
     store_previous_message_on_fuzzy_match: :boolean
   ]
@@ -273,6 +278,7 @@ defmodule Mix.Tasks.Gettext.Merge do
         :fuzzy,
         :fuzzy_threshold,
         :plural_forms,
+        :plural_forms_header,
         :on_obsolete,
         :store_previous_message_on_fuzzy_match
       ])

--- a/test/fixtures/single_messages/it/LC_MESSAGES/default.po
+++ b/test/fixtures/single_messages/it/LC_MESSAGES/default.po
@@ -1,3 +1,8 @@
+msgid ""
+msgstr ""
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 msgid "Hello world"
 msgstr "Ciao mondo"
 

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -23,6 +23,13 @@ defmodule GettextTest.TranslatorWithCustomPluralForms do
     plural_forms: GettextTest.CustomPlural
 end
 
+defmodule GettextTest.TranslatorWithCustomCompiledPluralForms do
+  use Gettext,
+    otp_app: :test_application,
+    priv: "test/fixtures/single_messages",
+    plural_forms: GettextTest.CustomCompiledPlural
+end
+
 defmodule GettextTest.TranslatorWithDefaultDomain do
   use Gettext,
     otp_app: :test_application,
@@ -77,6 +84,7 @@ defmodule GettextTest do
   alias GettextTest.Translator
   alias GettextTest.TranslatorWithAllowedLocalesString
   alias GettextTest.TranslatorWithAllowedLocalesAtom
+  alias GettextTest.TranslatorWithCustomCompiledPluralForms
   alias GettextTest.TranslatorWithCustomPluralForms
   alias GettextTest.TranslatorWithDefaultDomain
   alias GettextTest.HandleMissingMessage
@@ -201,6 +209,14 @@ defmodule GettextTest do
 
     assert T.lngettext("it", "default", nil, "One new email", "%{count} new emails", 2, %{}) ==
              {:ok, "Una nuova email"}
+  end
+
+  test "using a custom Gettext.Plural module with the context parameter" do
+    alias TranslatorWithCustomCompiledPluralForms, as: T
+
+    assert T.lngettext("it", "default", nil, "One new email", "%{count} new emails", 1, %{})
+
+    assert_received {:plural_context, %{plural_forms_header: "nplurals=2; plural=(n != 1);"}}
   end
 
   test "using a custom Gettext.Plural module from app environment" do

--- a/test/mix/tasks/gettext.merge_test.exs
+++ b/test/mix/tasks/gettext.merge_test.exs
@@ -204,7 +204,7 @@ defmodule Mix.Tasks.Gettext.MergeTest do
 
     output =
       capture_io(fn ->
-        run([@priv_path, "--locale", "it", "--plural-forms", "3"])
+        run([@priv_path, "--locale", "it", "--plural-forms-header", "nplurals=3"])
       end)
 
     assert output =~ "Wrote tmp/gettext.merge/it/LC_MESSAGES/new.po"

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,4 +7,25 @@ defmodule GettextTest.CustomPlural do
   def plural("it", _), do: 0
 end
 
+defmodule GettextTest.CustomCompiledPlural do
+  @behaviour Gettext.Plural
+
+  @impl Gettext.Plural
+  def init(context), do: context
+
+  @impl Gettext.Plural
+  def nplurals(context) do
+    send(self(), {:nplurals_context, context})
+
+    2
+  end
+
+  @impl Gettext.Plural
+  def plural(context, _count) do
+    send(self(), {:plural_context, context})
+
+    0
+  end
+end
+
 ExUnit.start()


### PR DESCRIPTION
Closes #318

This makes it possible to react precisely to the header instead of using predefined formats.