### PR TITLE
Fix duplicated filename in reference when using write_reference_line_numbers

### DIFF
--- a/lib/gettext/merger.ex
+++ b/lib/gettext/merger.ex
@@ -267,12 +267,19 @@ defmodule Gettext.Merger do
           Access.all()
         ]
 
+        references_accessor = [
+          Access.key!(:messages),
+          Access.all(),
+          Access.key!(:references)
+        ]
+
         all
         |> update_in(lines_accessor, fn
           {file, _line_number} -> file
           file -> file
         end)
         |> update_in(files_accessor, &Enum.uniq/1)
+        |> update_in(references_accessor, &Enum.uniq/1)
 
       true ->
         all

--- a/lib/gettext/merger.ex
+++ b/lib/gettext/merger.ex
@@ -252,7 +252,7 @@ defmodule Gettext.Merger do
         put_in(all, [Access.key!(:messages), Access.all(), Access.key(:references)], [])
 
       not write_line_numbers? ->
-        accessor = [
+        lines_accessor = [
           Access.key!(:messages),
           Access.all(),
           Access.key!(:references),
@@ -260,10 +260,19 @@ defmodule Gettext.Merger do
           Access.all()
         ]
 
-        update_in(all, accessor, fn
+        files_accessor = [
+          Access.key!(:messages),
+          Access.all(),
+          Access.key!(:references),
+          Access.all()
+        ]
+
+        all
+        |> update_in(lines_accessor, fn
           {file, _line_number} -> file
           file -> file
         end)
+        |> update_in(files_accessor, &Enum.uniq/1)
 
       true ->
         all

--- a/lib/gettext/merger.ex
+++ b/lib/gettext/merger.ex
@@ -252,7 +252,6 @@ defmodule Gettext.Merger do
         put_in(all, [Access.key!(:messages), Access.all(), Access.key(:references)], [])
 
       not write_line_numbers? ->
-
         references_accessor = [
           Access.key!(:messages),
           Access.all(),

--- a/lib/gettext/merger.ex
+++ b/lib/gettext/merger.ex
@@ -252,7 +252,6 @@ defmodule Gettext.Merger do
         put_in(all, [Access.key!(:messages), Access.all(), Access.key(:references)], [])
 
       not write_line_numbers? ->
-        all.messages
 
         references_accessor = [
           Access.key!(:messages),

--- a/test/gettext/merger_test.exs
+++ b/test/gettext/merger_test.exs
@@ -495,7 +495,8 @@ defmodule Gettext.MergerTest do
           %Message.Singular{
             msgid: "a",
             references: [
-              [{"path/to/file.ex", 12}, {"path/to/file.ex", 24}],
+              [{"path/to/file.ex", 12}, {"path/to/file.ex", 24}, {"a", 1}],
+              [{"path/to/file.ex", 42}, {"b", 1}],
               [{"path/to/file.ex", 42}],
               [{"path/to/other_file.ex", 24}]
             ]
@@ -508,7 +509,13 @@ defmodule Gettext.MergerTest do
 
       assert %Messages{
                messages: [
-                 %Message.Singular{references: [["path/to/file.ex"], ["path/to/other_file.ex"]]},
+                 %Message.Singular{
+                   references: [
+                     ["path/to/file.ex", "a"],
+                     ["b"],
+                     ["path/to/other_file.ex"]
+                   ]
+                 },
                  %Message.Plural{references: [["path/to/file.ex"]]}
                ]
              } = Merger.prune_references(po, config)

--- a/test/gettext/merger_test.exs
+++ b/test/gettext/merger_test.exs
@@ -496,6 +496,7 @@ defmodule Gettext.MergerTest do
             msgid: "a",
             references: [
               [{"path/to/file.ex", 12}, {"path/to/file.ex", 24}],
+              [{"path/to/file.ex", 42}],
               [{"path/to/other_file.ex", 24}]
             ]
           },

--- a/test/gettext/merger_test.exs
+++ b/test/gettext/merger_test.exs
@@ -492,7 +492,13 @@ defmodule Gettext.MergerTest do
     test "prunes reference line numbers when `write_reference_line_numbers` is `false`" do
       po = %Messages{
         messages: [
-          %Message.Singular{msgid: "a", references: [[{"path/to/file.ex", 12}]]},
+          %Message.Singular{
+            msgid: "a",
+            references: [
+              [{"path/to/file.ex", 12}, {"path/to/file.ex", 24}],
+              [{"path/to/other_file.ex", 24}]
+            ]
+          },
           %Message.Plural{msgid: "a", msgid_plural: "ab", references: [[{"path/to/file.ex", 12}]]}
         ]
       }
@@ -501,7 +507,7 @@ defmodule Gettext.MergerTest do
 
       assert %Messages{
                messages: [
-                 %Message.Singular{references: [["path/to/file.ex"]]},
+                 %Message.Singular{references: [["path/to/file.ex"], ["path/to/other_file.ex"]]},
                  %Message.Plural{references: [["path/to/file.ex"]]}
                ]
              } = Merger.prune_references(po, config)


### PR DESCRIPTION
Fixes #344 