### PR TITLE
fix: check-up-to-date check error

### DIFF
--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -79,9 +79,12 @@ defmodule Mix.Tasks.Gettext.Extract do
   end
 
   defp run_up_to_date_check(pot_files) do
-    not_extracted_paths = for {path, _contents} <- pot_files, do: path
+    not_extracted_paths =
+      for {path, contents} <- pot_files,
+          not File.exists?(path) or File.read!(path) != IO.iodata_to_binary(contents),
+          do: path
 
-    if pot_files == [] do
+    if not_extracted_paths == [] do
       :ok
     else
       Mix.raise("""


### PR DESCRIPTION
We started getting the error below:

![Screenshot 2023-01-20 at 16 55 40](https://user-images.githubusercontent.com/10515908/213744622-90eef71f-7400-4a08-aa36-43088fbdcd79.png)

It might have been introduced after our recent upgrade to version `0.21.0`.