### PR TITLE
Fix extractor crash in case of conflicting backends

### DIFF
--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -121,6 +121,7 @@ defmodule Gettext.Extractor do
               "Please set the :priv option to different directories or use Gettext " <>
               "inside each backend"
           )
+
           acc
 
         %{} ->

--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -121,6 +121,7 @@ defmodule Gettext.Extractor do
               "Please set the :priv option to different directories or use Gettext " <>
               "inside each backend"
           )
+          acc
 
         %{} ->
           Map.put(acc, priv, backend)


### PR DESCRIPTION
I have in the same app 2 gettext backends, each one having its own domain.
I want both backend translation files to live in the same usual `priv/gettext` folder: the different domain name ensures they will not overwrite each other.

When extracting translations the `warn_on_conflicting_backends/1` function issues a warning about that case but then it also crashes:

```shell
warning: the Gettext backend Blog.Gettext has the same :priv directory as Marketplace.Gettext, which means they will override each other. Please set the :priv option to different directories or use Gettext inside each backend
  (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
  (gettext 0.22.0) lib/gettext/extractor.ex:103: Gettext.Extractor.pot_files/2
  (gettext 0.22.0) lib/mix/tasks/gettext.extract.ex:109: Mix.Tasks.Gettext.Extract.extract/2
  (gettext 0.22.0) lib/mix/tasks/gettext.extract.ex:68: Mix.Tasks.Gettext.Extract.run/1
  (mix 1.14.3) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
  (mix 1.14.3) lib/mix/project.ex:397: Mix.Project.in_project/4

** (CaseClauseError) no case clause matching: :ok
    (gettext 0.22.0) lib/gettext/extractor.ex:116: anonymous fn/2 in Gettext.Extractor.warn_on_conflicting_backends/1
    (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (gettext 0.22.0) lib/gettext/extractor.ex:103: Gettext.Extractor.pot_files/2
    (gettext 0.22.0) lib/mix/tasks/gettext.extract.ex:109: Mix.Tasks.Gettext.Extract.extract/2
    (gettext 0.22.0) lib/mix/tasks/gettext.extract.ex:68: Mix.Tasks.Gettext.Extract.run/1
    (mix 1.14.3) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.3) lib/mix/project.ex:397: Mix.Project.in_project/4
    (elixir 1.14.3) lib/file.ex:1607: File.cd!/2
```

This prevents the crash, the warning is still there but my gettext.extract command is working.