### PR TITLE
Implement `Plural.plural_forms_header/1` for default implementation

### DIFF
--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -350,6 +350,15 @@ defmodule Gettext.Plural do
     end
   end
 
+  def plural_forms_header(locale) do
+    case Expo.PluralForms.plural_form(locale) do
+      {:ok, plural_form} -> Expo.PluralForms.to_string(plural_form)
+      :error -> recall_if_territory_or_raise(locale, &plural_forms_header(&1))
+    end
+  rescue
+    UnknownLocaleError -> nil
+  end
+
   defp recall_if_territory_or_raise(locale, fun) do
     case String.split(locale, "_", parts: 2, trim: true) do
       [lang, _territory] -> fun.(lang)

--- a/test/mix/tasks/gettext.merge_test.exs
+++ b/test/mix/tasks/gettext.merge_test.exs
@@ -219,7 +219,7 @@ defmodule Mix.Tasks.Gettext.MergeTest do
            msgid ""
            msgstr ""
            "Language: it\n"
-           "Plural-Forms: nplurals=2\n"
+           "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
            msgid "new"
            msgstr ""


### PR DESCRIPTION
I found that we generate the outdated `nplurals=X` only headers by default when using `gettext.merge` for a new locale. That will directly result in a deprecation warning.