### PR TITLE
fix: Gettext.Extractor references no function clause matching

### DIFF
--- a/lib/gettext/extractor.ex
+++ b/lib/gettext/extractor.ex
@@ -422,5 +422,5 @@ defmodule Gettext.Extractor do
     do: false
 
   defp protected?(%{references: refs}, pattern),
-    do: Enum.any?(refs, fn {path, _} -> Regex.match?(pattern, path) end)
+    do: refs |> List.flatten() |> Enum.any?(fn {path, _} -> Regex.match?(pattern, path) end)
 end

--- a/test/gettext/extractor_test.exs
+++ b/test/gettext/extractor_test.exs
@@ -91,7 +91,7 @@ defmodule Gettext.ExtractorTest do
       message_1 = %Message.Singular{
         msgid: ["foo"],
         msgstr: ["bar"],
-        references: [{"foo.ex", 1}],
+        references: [[{"foo.ex", 1}, {"bar.ex", 1}], [{"baz.ex", 1}]],
         flags: [["elixir-autogen", "elixir-format"]]
       }
 


### PR DESCRIPTION
```elixir
  1) test merge_template/2 allowed messages are kept (Gettext.ExtractorTest)
     test/gettext/extractor_test.exs:90
     ** (FunctionClauseError) no function clause matching in anonymous fn/1 in Gettext.Extractor.protected?/2

     The following arguments were given to anonymous fn/1 in Gettext.Extractor.protected?/2:
     
         # 1
         [{"foo.ex", 1}, {"bar.ex", 1}]
     
     code: assert Extractor.merge_template(old, new, excluded_refs_from_purging: ~r{^web/static/}) ==
     stacktrace:
       (gettext 0.23.0-dev) lib/gettext/extractor.ex:425: anonymous fn/1 in Gettext.Extractor.protected?/2
       (elixir 1.14.1) lib/enum.ex:4136: Enum.any_list/2
       (gettext 0.23.0-dev) lib/gettext/extractor.ex:295: anonymous fn/3 in Gettext.Extractor.merge_template/3
       (elixir 1.14.1) lib/enum.ex:4249: Enum.flat_map_list/2
       (gettext 0.23.0-dev) lib/gettext/extractor.ex:292: Gettext.Extractor.merge_template/3
       test/gettext/extractor_test.exs:107: (test)

```