### PR TITLE
Change from ensure_loaded/1 to ensure_compiled/1

### DIFF
--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -368,7 +368,7 @@ defmodule Gettext.Plural do
 
   @doc false
   def plural_info(locale, messages_struct, plural_mod) do
-    ensure_loaded!(plural_mod)
+    ensure_compiled!(plural_mod)
 
     if function_exported?(plural_mod, :init, 1) do
       pluralization_context =
@@ -385,7 +385,7 @@ defmodule Gettext.Plural do
 
   @doc false
   def plural_forms_header_impl(locale, messages_struct, plural_mod) do
-    ensure_loaded!(plural_mod)
+    ensure_compiled!(plural_mod)
 
     plural_forms_header =
       if function_exported?(plural_mod, :plural_forms_header, 1) do
@@ -402,9 +402,9 @@ defmodule Gettext.Plural do
 
   # TODO: remove when we depend on Elixir 1.12+
   if function_exported?(Code, :ensure_compiled!, 1) do
-    defp ensure_loaded!(mod), do: Code.ensure_compiled!(mod)
+    defp ensure_compiled!(mod), do: Code.ensure_compiled!(mod)
   else
-    defp ensure_loaded!(mod) do
+    defp ensure_compiled!(mod) do
       case Code.ensure_compiled(mod) do
         {:module, ^mod} ->
           mod

--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -401,8 +401,8 @@ defmodule Gettext.Plural do
   end
 
   # TODO: remove when we depend on Elixir 1.12+
-  if function_exported?(Code, :ensure_loaded!, 1) do
-    defp ensure_loaded!(mod), do: Code.ensure_loaded!(mod)
+  if function_exported?(Code, :ensure_compiled!, 1) do
+    defp ensure_loaded!(mod), do: Code.ensure_compiled!(mod)
   else
     defp ensure_loaded!(mod) do
       case Code.ensure_compiled(mod) do

--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -405,7 +405,7 @@ defmodule Gettext.Plural do
     defp ensure_loaded!(mod), do: Code.ensure_loaded!(mod)
   else
     defp ensure_loaded!(mod) do
-      case Code.ensure_loaded(mod) do
+      case Code.ensure_compiled(mod) do
         {:module, ^mod} ->
           mod
 


### PR DESCRIPTION
Fixes https://github.com/elixir-gettext/gettext/issues/358

We can't use ensure_compiled!/1 for versions under 1.12+