### PR TITLE
Ensure all modules are properly loaded for "mix gettext.merge"

### DIFF
--- a/lib/mix/tasks/gettext.merge.ex
+++ b/lib/mix/tasks/gettext.merge.ex
@@ -137,6 +137,8 @@ defmodule Mix.Tasks.Gettext.Merge do
 
   @impl true
   def run(args) do
+    Mix.Task.run("loadpaths")
+
     _ = Mix.Project.get!()
     gettext_config = Mix.Project.config()[:gettext] || []
 


### PR DESCRIPTION
`:nofile` error of #358 has been solved for a while, but I found it's not solved completely. 

I can still see the `:nofile` error when working with **Gettext with custom plural module**. I created a repo for reproducing the problem:
+ repo: https://github.com/plastic-gun/elixir-gettext-nofile
+ every commit in this repo is self-descriptive, you can track them to reproduce the problem.
+ `README.md` contains the following contents:
   - how to reproduce?
   - what is wrong?
   - the problem 
   - the reason
   - the solution
   
---

I found the solution is very easy - use `mix loadpaths`, such as:

```sh 
$ mix do loadpaths + gettext.merge priv/gettext --locale en_US
```

But, to minimize surprises, I believe it would be better to make the changes within `Mix.Tasks.Gettext.Merge`, which helps to reduce the friction for other developers. This PR does it.

> I don't have a comprehensive understanding of mix's workings yet, so the solution in this PR maybe not perfect. Welcome to comment. ;)
>
> And, I want to create a test for this case, but I don't know how. Sorry for that :(