### PR TITLE
Don't rely on the the last-update timestamp of the manifest for extract mix task

### DIFF
--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Gettext.Extract do
 
   defp force_compile do
     Mix.Tasks.Compile.Elixir.clean()
-    Enum.each(Mix.Tasks.Compile.Elixir.manifests(), &File.rm/1) 
+    Enum.each(Mix.Tasks.Compile.Elixir.manifests(), &File.rm/1)
 
     # If "compile" was never called, the reenabling is a no-op and
     # "compile.elixir" is a no-op as well (because it wasn't reenabled after

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Gettext.Extract do
   end
 
   defp force_compile do
-    Enum.map(Mix.Tasks.Compile.Elixir.manifests(), &make_old_if_exists/1)
+    Enum.map(Mix.Tasks.Compile.Elixir.manifests(), &File.rm/1)
 
     # If "compile" was never called, the reenabling is a no-op and
     # "compile.elixir" is a no-op as well (because it wasn't reenabled after
@@ -122,10 +122,6 @@ defmodule Mix.Tasks.Gettext.Extract do
     Mix.Task.reenable("compile.elixir")
     Mix.Task.run("compile")
     Mix.Task.run("compile.elixir", ["--force"])
-  end
-
-  defp make_old_if_exists(path) do
-    :file.change_time(path, {{2000, 1, 1}, {0, 0, 0}})
   end
 
   defp run_merge(pot_files, argv) do

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Gettext.Extract do
   end
 
   defp force_compile do
-    Enum.map(Mix.Tasks.Compile.Elixir.manifests(), &File.rm/1)
+    Mix.Tasks.Compile.Elixir.clean()
 
     # If "compile" was never called, the reenabling is a no-op and
     # "compile.elixir" is a no-op as well (because it wasn't reenabled after

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -113,6 +113,7 @@ defmodule Mix.Tasks.Gettext.Extract do
 
   defp force_compile do
     Mix.Tasks.Compile.Elixir.clean()
+    Enum.each(Mix.Tasks.Compile.Elixir.manifests(), &File.rm/1) 
 
     # If "compile" was never called, the reenabling is a no-op and
     # "compile.elixir" is a no-op as well (because it wasn't reenabled after

--- a/mix.lock
+++ b/mix.lock
@@ -14,6 +14,6 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
Don't rely on the the last-update timestamp of the manifest to trigger a forced compilation with the Elixir compiler.

The Mix task needs to be re-run, to ensure that previous compilations don't turn this in a noop. This assumes the `compiler.elixir` is sufficient for extracting messages.

Closes #367.

Needs thorough review though, I'm not sure of all the consequences.