### PR TITLE
Remove unused private macro ends_in/2

### DIFF
--- a/lib/gettext/plural.ex
+++ b/lib/gettext/plural.ex
@@ -248,14 +248,6 @@ defmodule Gettext.Plural do
 
   # Behaviour implementation.
 
-  defmacrop ends_in(n, digits) do
-    digits = List.wrap(digits)
-
-    quote do
-      rem(unquote(n), 10) in unquote(digits)
-    end
-  end
-
   # Default implementation of the init/1 callback, in case the user uses
   # Gettext.Plural as their plural forms module.
   @doc false


### PR DESCRIPTION
An unused private macro emits a warning on Elixir 1.16. Since `ends_in/2` is unused, this PR deletes it. All tests pass.