### PR TITLE
Release `v0.24.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.24.0
+
+  * Handle singular and plural messages with the same `msgid` as the same
+    message.
+
+    This change produces a `Expo.PO.DuplicateMessagesError` if you already have
+    messages with the same singular `msgid`. This can be solved by calling the
+    `expo.msguniq` mix task on your `.po` file:
+
+    ```bash
+    mix expo.msguniq \
+      priv/gettext/LOCALE/LC_MESSAGES/DOMAIN.po \
+      --output-file priv/gettext/LOCALE/LC_MESSAGES/DOMAIN.po
+    ```
+
 ## v0.23.1
 
   * Use the Hex version of the excoveralls dependency.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Gettext.Mixfile do
   use Mix.Project
 
-  @version "0.24.0-dev"
+  @version "0.24.0"
 
   @description "Internationalization and localization through gettext"
   @repo_url "https://github.com/elixir-gettext/gettext"


### PR DESCRIPTION
I though it makes sense to highlight the way to fix a `Expo.PO.DuplicateMessagesError` directly in the changelog.

I would classify this is a patch release since we handled the messages differently from GNU gettext. Do you agree @whatyouhide or should this be `v0.24.0`?