### PR TITLE
Introduce "use Gettext.Backend"

### DIFF
--- a/lib/gettext.ex
+++ b/lib/gettext.ex
@@ -633,6 +633,7 @@ defmodule Gettext do
       if Keyword.has_key?(opts, :backend) do
         raise "not implemented yet"
       else
+        # TODO: Deprecate this branch
         require Gettext.Backend
         Gettext.Backend.__using__(opts)
       end

--- a/lib/gettext/backend.ex
+++ b/lib/gettext/backend.ex
@@ -27,13 +27,6 @@ defmodule Gettext.Backend do
     # TODO: From Elixir v1.13 onwards, use compile_env and remove this if.
     env_fun = if function_exported?(Module, :attributes_in, 1), do: :compile_env, else: :get_env
 
-    opts =
-      if Macro.quoted_literal?(opts) do
-        Macro.prewalk(opts, &expand_alias(&1, __CALLER__))
-      else
-        opts
-      end
-
     quote do
       require Logger
 
@@ -81,14 +74,6 @@ defmodule Gettext.Backend do
 
       defoverridable handle_missing_translation: 5, handle_missing_plural_translation: 7
     end
-  end
-
-  defp expand_alias({:__aliases__, _, _} = als, env) do
-    Macro.expand(als, %{env | function: {:__gettext__, 1}})
-  end
-
-  defp expand_alias(other, _env) do
-    other
   end
 
   @doc """

--- a/test/gettext/backend_test.exs
+++ b/test/gettext/backend_test.exs
@@ -1,0 +1,18 @@
+defmodule Gettext.BackendTest do
+  use ExUnit.Case, async: true
+
+  describe "use Gettext.Backend" do
+    test "creates a backend" do
+      body =
+        quote do
+          use Gettext.Backend,
+            otp_app: :test_application
+        end
+
+      {:module, mod, _bytecode, :ok} = Module.create(TestBackend, body, __ENV__)
+
+      assert mod.__gettext__(:otp_app) == :test_application
+      assert mod.__info__(:attributes)[:behaviour] == [Gettext.Backend]
+    end
+  end
+end


### PR DESCRIPTION
This starts to address #330 by allowing `use Gettext.Backend` in place of `use Gettext`. Small steps, and this should be easy to review 🙃 

I left all the test modules to `use Gettext` because we'll change that later on anyway.