### PR TITLE
Mention `igniter` in v0.26 Changelog Migration Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ If you update Gettext and still use `use Gettext, otp_app: :my_app` to define a 
 
 If your project is using [`igniter`](https://hex.pm/packages/igniter), you can run
 [`mix igniter.update_gettext`](https://hexdocs.pm/igniter/Mix.Tasks.Igniter.UpdateGettext.html)
-to automatically migrate to the new conventions.
+to automatically migrate to the new API.
 
 ### Detailed Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ We are also updating [Phoenix](https://github.com/phoenixframework/phoenix) gene
 
 If you update Gettext and still use `use Gettext, otp_app: :my_app` to define a backend, Gettext will emit a warning now.
 
-### Migration using igniter
+### Migration with Igniter
 
 If your project is using [`igniter`](https://hex.pm/packages/igniter), you can run
 [`mix igniter.update_gettext`](https://hexdocs.pm/igniter/Mix.Tasks.Igniter.UpdateGettext.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ We are also updating [Phoenix](https://github.com/phoenixframework/phoenix) gene
 
 If you update Gettext and still use `use Gettext, otp_app: :my_app` to define a backend, Gettext will emit a warning now.
 
+### Migration using igniter
+
+If your project is using [`igniter`](https://hex.pm/packages/igniter), you can run
+[`mix igniter.update_gettext`](https://hexdocs.pm/igniter/Mix.Tasks.Igniter.UpdateGettext.html)
+to automatically migrate to the new conventions.
+
 ### Detailed Changelog
 
 This is a detailed list of the new things introduced in this release:


### PR DESCRIPTION
Zach built a nice igniter mix migration task. I thought it would be good to mention it in the changelog to make the update simpler for our users.