### PR TITLE
Release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.27.0
+
+* Introduces warning if plural messages are defined with the same singular
+  message and conflicting plural messages.
+* Improves performance by striping not required metadata when compiling the
+  Gettext backend.
+
 ## v0.26.1
 
   * Address backwards incompatible changes in previous release

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Gettext.Mixfile do
   use Mix.Project
 
-  @version "0.26.1"
+  @version "0.27.0"
 
   @description "Internationalization and localization through gettext"
   @repo_url "https://github.com/elixir-gettext/gettext"


### PR DESCRIPTION
I would consider the metadata stripping functionality a new feature and would therefore go to 0.27.0 instead of 0.26.2.

But since this does not directly affect the user, one could also argue for a patch release. What do you prefer?