### PR TITLE
Fix concatenation of sigils

### DIFF
--- a/lib/gettext/macros.ex
+++ b/lib/gettext/macros.ex
@@ -709,25 +709,25 @@ defmodule Gettext.Macros do
       """
     end
 
-    do_expand_to_binary(term, env, raiser)
+    validated_expand_to_binary(term, env, raiser)
   end
 
-  defp do_expand_to_binary({:<>, _, pieces}, env, raiser) do
-    Enum.map_join(pieces, &do_expand_to_binary(&1, env, raiser))
+  defp validated_expand_to_binary({:<>, _, pieces}, env, raiser) do
+    Enum.map_join(pieces, &validated_expand_to_binary(&1, env, raiser))
   end
 
-  defp do_expand_to_binary({:<<>>, _, pieces}, env, raiser) do
-    Enum.map_join(pieces, &do_expand_to_binary(&1, env, raiser))
+  defp validated_expand_to_binary({:<<>>, _, pieces}, env, raiser) do
+    Enum.map_join(pieces, &validated_expand_to_binary(&1, env, raiser))
   end
 
   # We support nil too in order to fall back to a nil context and always use the *p
   # variants of the Gettext macros.
-  defp do_expand_to_binary(term, _env, _raiser)
+  defp validated_expand_to_binary(term, _env, _raiser)
        when is_binary(term) or is_nil(term) do
     term
   end
 
-  defp do_expand_to_binary(term, env, raiser) do
+  defp validated_expand_to_binary(term, env, raiser) do
     case Macro.expand(term, env) do
       term when is_binary(term) or is_nil(term) ->
         term

--- a/test/gettext/macros_test.exs
+++ b/test/gettext/macros_test.exs
@@ -15,12 +15,13 @@ defmodule Gettext.MacrosTest do
   @backend Gettext.MacrosTest.Translator
   @gettext_msgid "Hello world"
 
-  describe "gettext/2" do
+  describe "gettext/1" do
     test "supports binary-ish msgid at compile-time" do
       Gettext.put_locale(@backend, "it")
       assert gettext("Hello world") == "Ciao mondo"
       assert gettext(@gettext_msgid) == "Ciao mondo"
       assert gettext(~s(Hello world)) == "Ciao mondo"
+      assert gettext("Hello " <> "world") == "Ciao mondo"
     end
   end
 

--- a/test/gettext/macros_test.exs
+++ b/test/gettext/macros_test.exs
@@ -22,6 +22,8 @@ defmodule Gettext.MacrosTest do
       assert gettext(@gettext_msgid) == "Ciao mondo"
       assert gettext(~s(Hello world)) == "Ciao mondo"
       assert gettext("Hello " <> "world") == "Ciao mondo"
+      assert gettext("Hello " <> ~s(world)) == "Ciao mondo"
+      assert gettext(~S(Hello ) <> ~s(world)) == "Ciao mondo"
     end
   end
 

--- a/test/gettext/macros_test.exs
+++ b/test/gettext/macros_test.exs
@@ -22,6 +22,10 @@ defmodule Gettext.MacrosTest do
       assert gettext(@gettext_msgid) == "Ciao mondo"
       assert gettext(~s(Hello world)) == "Ciao mondo"
       assert gettext("Hello " <> "world") == "Ciao mondo"
+      assert gettext("Hello " <> "wor" <> "ld") == "Ciao mondo"
+      assert gettext(<<"Hello world">>) == "Ciao mondo"
+      assert gettext(<<"Hello ", "world">>) == "Ciao mondo"
+      assert gettext("Hello " <> <<"wor", "ld">>) == "Ciao mondo"
       assert gettext("Hello " <> ~s(world)) == "Ciao mondo"
       assert gettext(~S(Hello ) <> ~s(world)) == "Ciao mondo"
     end


### PR DESCRIPTION
Add support for concatenation with sigils (e.g. `"Hello " <> ~s(world)`).

Fixes #411
