### PR TITLE
Don't time out when running the extract task

### DIFF
--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.Gettext.Extract do
     pot_files
     |> Enum.map(fn {path, _} -> Path.dirname(path) end)
     |> Enum.uniq()
-    |> Task.async_stream(&Mix.Tasks.Gettext.Merge.run([&1 | argv]), ordered: false)
+    |> Task.async_stream(&Mix.Tasks.Gettext.Merge.run([&1 | argv]), ordered: false, timeout: :infinity)
     |> Stream.run()
   end
 end

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.Gettext.Extract do
     pot_files
     |> Enum.map(fn {path, _} -> Path.dirname(path) end)
     |> Enum.uniq()
-    |> Task.async_stream(&Mix.Tasks.Gettext.Merge.run([&1 | argv]), ordered: false, timeout: :infinity)
+    |> Task.async_stream(&Mix.Tasks.Gettext.Merge.run([&1 | argv]), ordered: false, timeout: 120_000)
     |> Stream.run()
   end
 end

--- a/lib/mix/tasks/gettext.extract.ex
+++ b/lib/mix/tasks/gettext.extract.ex
@@ -129,7 +129,10 @@ defmodule Mix.Tasks.Gettext.Extract do
     pot_files
     |> Enum.map(fn {path, _} -> Path.dirname(path) end)
     |> Enum.uniq()
-    |> Task.async_stream(&Mix.Tasks.Gettext.Merge.run([&1 | argv]), ordered: false, timeout: 120_000)
+    |> Task.async_stream(&Mix.Tasks.Gettext.Merge.run([&1 | argv]),
+      ordered: false,
+      timeout: 120_000
+    )
     |> Stream.run()
   end
 end


### PR DESCRIPTION
Set a timeout of :infinity when running extract. This is in line with the setting for the merge operation.

Fixes #416